### PR TITLE
Add document formatting abilities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "trie-search": "2.2.0",
         "vscode-languageserver": "9.0.1",
         "vscode-languageserver-textdocument": "1.0.12",
+        "vscode-uri": "3.1.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -53,6 +54,8 @@
     "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
 
     "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
     "bun-types/@types/node": ["@types/node@24.2.0", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw=="],
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "trie-search": "2.2.0",
     "vscode-languageserver": "9.0.1",
-    "vscode-languageserver-textdocument": "1.0.12"
+    "vscode-languageserver-textdocument": "1.0.12",
+    "vscode-uri": "3.1.0"
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,10 @@ import provideDistributionCompletions from "./language/completion/providers/dist
 import provideFunctionCompletions from "./language/completion/providers/functions";
 import provideKeywordCompletions from "./language/completion/providers/keywords";
 import provideDatatypeCompletions from "./language/completion/providers/datatypes";
+import { compile } from "./stanc/compiler";
+import { getIncludes } from "./stanc/includes";
+import { URI, Utils as URIUtils } from "vscode-uri";
+import { promises as fs } from "fs";
 
 const connection = createConnection(process.stdin, process.stdout);
 
@@ -18,12 +22,19 @@ const documents = new TextDocuments(TextDocument);
 
 connection.onInitialize((params: InitializeParams): InitializeResult => {
   connection.console.info("Initializing Stan language server...");
+
   return {
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       completionProvider: {
         triggerCharacters: ["~"], // Trigger completion after tilde
         resolveProvider: false, // Set to true if you implement resolve
+      },
+      documentFormattingProvider: true, // Enable document formatting
+      workspace: {
+        workspaceFolders: {
+          supported: true,
+        },
       },
       // Add more capabilities as needed
     },
@@ -57,6 +68,67 @@ connection.onCompletion((params) => {
     ...datatypes,
   ];
   return candidates;
+});
+
+const getIncludeHelperForFile = (currentFilePath: URI) => {
+  return getIncludes(async (filename: string) => {
+    const currentDir = URIUtils.dirname(currentFilePath);
+
+    // first, try to look it up in files already known to the server
+    let folders = (await connection.workspace.getWorkspaceFolders()) || [];
+    // insert path.dirname of current file
+    folders = [
+      { uri: currentDir.toString(), name: "current directory" },
+      ...folders,
+    ];
+    for (const folder of folders) {
+      const include_path = folder.uri + "/" + filename;
+      const include = documents.get(include_path);
+      if (include) {
+        return include.getText();
+      }
+    }
+
+    // fall back to reading from the filesystem
+    if (currentDir.scheme === "file") {
+      const includePath = URIUtils.joinPath(currentDir, filename);
+      return await fs.readFile(includePath.fsPath, "utf-8");
+    }
+
+    connection.console.error(`Include file not found: ${filename}`);
+    throw new Error(`Include file not found: ${filename}`);
+  });
+};
+
+connection.onDocumentFormatting(async (params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (document) {
+    const getIncludesFn = getIncludeHelperForFile(URI.parse(document.uri));
+    const result = await compile(getIncludesFn)(document);
+
+    if (result.result) {
+      // Stan compiler only formats entire documents
+      const range = {
+        start: { line: 0, character: 0 },
+        end: {
+          line: document.lineCount - 1,
+          character: document.getText().length,
+        },
+      };
+      return [
+        {
+          range,
+          newText: result.result,
+        },
+      ];
+    } else if (result.errors) {
+      connection.console.error("Formatting error:");
+      for (const line of result.errors[1]?.split("\n") || []) {
+        connection.console.error(line);
+      }
+    }
+  }
+  return [];
 });
 
 documents.listen(connection);

--- a/src/stanc/compiler.ts
+++ b/src/stanc/compiler.ts
@@ -71,6 +71,9 @@ export const compile =
       "allow-undefined",
       ...args,
     ];
+    if (document.languageId === "stanfunctions") {
+      stanc_args.push("functions-only");
+    }
     // logger.appendLine(
     //   `Running stanc on ${filename} with args: ${stanc_args.join(", ")}, and includes: ${Object.keys(includes).join(", ")}`,
     // );


### PR DESCRIPTION
Adds a `documentFormattingProvider`.

The function `getIncludeHelperForFile` is (I think) a valid implementation that we should be able to re-use for diagnostic providing with the compiler as well. Might be good to do that next?