### PR TITLE
Port hover documentation from VScode

### DIFF
--- a/src/language/hover/distributions.ts
+++ b/src/language/hover/distributions.ts
@@ -1,0 +1,60 @@
+import type { Hover } from "vscode-languageserver";
+import { getMathDistributions } from "../../stanc/compiler";
+import { getFunctionDocumentation } from "./functions";
+import type {
+  TextDocument,
+  Position,
+} from "vscode-languageserver-textdocument";
+
+const distributionToFunctionMap: Map<string, string> = new Map();
+
+export const setupDistributionMap = () => {
+  const mathDistributions = getMathDistributions();
+  const distLines = mathDistributions.split("\n");
+  for (const line of distLines) {
+    const [name, extensions] = line.split(":", 2);
+    if (!name || !extensions) {
+      continue;
+    }
+    const extension = extensions.split(",", 1)[0]?.trim();
+    distributionToFunctionMap.set(name, `${name}_${extension}`);
+  }
+};
+
+export const tryDistributionHover = (
+  document: TextDocument,
+  position: Position
+): Hover | undefined => {
+  const text = document.getText();
+
+  let offset = document.offsetAt(position) + 1; // include the character at the cursor position
+
+  const next_break = text.substring(offset).search(/[\s;\(\),\[\]]/);
+  if (next_break !== -1) offset += next_break;
+
+  // try to find distribution before
+  const dist = text.substring(0, offset).match(/~\s*([\w_]+)$/);
+  if (dist && dist[1]) {
+    const functionName = distributionToFunctionMap.get(dist[1]);
+    if (functionName) {
+      const contents = getFunctionDocumentation(functionName);
+      if (!contents) {
+        return undefined;
+      }
+
+      let range = undefined;
+      if (dist.index !== undefined) {
+        range = {
+          start: document.positionAt(dist.index),
+          end: document.positionAt(dist.index + dist[0].length),
+        };
+      }
+
+      return {
+        contents,
+        range,
+      };
+    }
+  }
+  return undefined;
+};

--- a/src/language/hover/distributions.ts
+++ b/src/language/hover/distributions.ts
@@ -23,23 +23,21 @@ export const setupDistributionMap = () => {
 
 export const tryDistributionHover = (
   document: TextDocument,
-  position: Position
-): Hover | undefined => {
+  endOfWord: number
+): Hover | null => {
   const text = document.getText();
 
-  let offset = document.offsetAt(position) + 1; // include the character at the cursor position
-
-  const next_break = text.substring(offset).search(/[\s;\(\),\[\]]/);
-  if (next_break !== -1) offset += next_break;
-
   // try to find distribution before
-  const dist = text.substring(0, offset).match(/~\s*([\w_]+)$/);
+  const dist = text
+    .substring(0, endOfWord)
+    .trimEnd()
+    .match(/~\s*(\w+)$/d);
   if (dist && dist[1]) {
     const functionName = distributionToFunctionMap.get(dist[1]);
     if (functionName) {
       const contents = getFunctionDocumentation(functionName);
       if (!contents) {
-        return undefined;
+        return null;
       }
 
       let range = undefined;
@@ -56,5 +54,6 @@ export const tryDistributionHover = (
       };
     }
   }
-  return undefined;
+
+  return null;
 };

--- a/src/language/hover/functions.ts
+++ b/src/language/hover/functions.ts
@@ -1,0 +1,93 @@
+import type { Hover, MarkupContent } from "vscode-languageserver";
+import { getMathSignatures } from "../../stanc/compiler";
+import type {
+  TextDocument,
+  Position,
+} from "vscode-languageserver-textdocument";
+
+const functionSignatureMap: Map<string, MarkupContent> = new Map();
+
+const getDocumentationForFunction = (name: string): MarkupContent => {
+  return {
+    kind: "markdown",
+    value: `[Jump to Stan Functions Reference index entry for ${name}](https://mc-stan.org/docs/functions-reference/functions_index.html#${name})`,
+  };
+};
+
+const appendCodeblock = (content: MarkupContent | undefined, code: string) => {
+  if (!content) {
+    return;
+  }
+  content.value += "\n```stan\n";
+  content.value += code;
+  content.value += "\n```";
+};
+
+export function setupSignatureMap() {
+  const mathSignatures = getMathSignatures();
+  const lines = mathSignatures.split("\n");
+  for (const line of lines) {
+    const [name] = line.split("(", 1);
+    if (!name) {
+      continue;
+    }
+    if (functionSignatureMap.has(name)) {
+      appendCodeblock(functionSignatureMap.get(name), line);
+    } else {
+      const doc = getDocumentationForFunction(name);
+      doc.value += "\n\n**Available signatures**:";
+      appendCodeblock(doc, line);
+
+      functionSignatureMap.set(name, doc);
+    }
+  }
+  // not technically 'functions', but still useful
+  functionSignatureMap.set("print", getDocumentationForFunction("print"));
+  functionSignatureMap.set("reject", getDocumentationForFunction("reject"));
+  functionSignatureMap.set(
+    "fatal_error",
+    getDocumentationForFunction("fatal_error")
+  );
+  functionSignatureMap.set("target", getDocumentationForFunction("target"));
+}
+
+export const getFunctionDocumentation = (
+  name: string
+): MarkupContent | undefined => {
+  return functionSignatureMap.get(name);
+};
+
+export const tryFunctionHover = (
+  document: TextDocument,
+  position: Position
+): Hover | undefined => {
+  const text = document.getText();
+
+  let offset = document.offsetAt(position) + 1; // include the character at the cursor position
+
+  const next_paren = text.indexOf("(", offset);
+  if (next_paren !== -1) {
+    const func = text.substring(0, next_paren + 1).match(/[\w_]+\s*\($/);
+    if (func) {
+      const funcName = func[0].replace("(", "").trim();
+      const contents = getFunctionDocumentation(funcName);
+      if (!contents) {
+        return undefined;
+      }
+
+      let range = undefined;
+      if (func.index !== undefined) {
+        range = {
+          start: document.positionAt(func.index),
+          end: document.positionAt(func.index + funcName.length),
+        };
+      }
+
+      return {
+        contents,
+        range,
+      };
+    }
+  }
+  return undefined;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -144,13 +144,26 @@ connection.onDocumentFormatting(async (params) => {
 
 connection.onHover((params) => {
   const document = documents.get(params.textDocument.uri);
-  if (document) {
-    const distributionHover = tryDistributionHover(document, params.position);
+
+  if (!document) {
+    return null;
+  }
+
+  const text = document.getText();
+
+  let offset = document.offsetAt(params.position); // include the character at the cursor position
+
+  const next_paren = text.substring(offset).match(/^\w+\s*\(/);
+  if (next_paren) {
+    const endOfWord = offset + next_paren[0].length - 1;
+
+    const distributionHover = tryDistributionHover(document, endOfWord);
     if (distributionHover) return distributionHover;
 
-    const functionHover = tryFunctionHover(document, params.position);
+    const functionHover = tryFunctionHover(document, endOfWord);
     if (functionHover) return functionHover;
   }
+
   return null;
 });
 


### PR DESCRIPTION
@tomatitito I'm not super familiar with the style you used in other files (e.g. that looks like `export functionName(appliedToFunction)`) but I'm guessing you'd prefer that rather than the `setup` functions here?

Output:
<img width="1348" height="856" alt="image" src="https://github.com/user-attachments/assets/05d1b1d6-415c-4a64-b619-5de528443798" />
