### PR TITLE
Add support for configuration

### DIFF
--- a/src/__tests__/handlers/compilation.test.ts
+++ b/src/__tests__/handlers/compilation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, spyOn, beforeEach, afterEach, mock } from "bun:te
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { TextDocuments, WorkspaceFolder } from "vscode-languageserver";
 import type { RemoteConsole } from "vscode-languageserver";
-import { handleCompilation } from "../../handlers/compilation/compilation";
+import { defaultSettings, handleCompilation } from "../../handlers/compilation/compilation";
 import * as includesModule from "../../handlers/compilation/includes";
 
 describe("Compilation Handler", () => {
@@ -12,7 +12,7 @@ describe("Compilation Handler", () => {
 
   beforeEach(() => {
     handleIncludesSpy = spyOn(includesModule, "handleIncludes").mockResolvedValue({});
-    
+
     mockLogger = {
       warn: mock(() => {}),
     } as any;
@@ -33,7 +33,7 @@ describe("Compilation Handler", () => {
 
   it("should compile Stan model successfully", async () => {
     const document = createDocument("file:///test.stan", "parameters { real x; } model { x ~ normal(0, 1); }");
-    const result = await handleCompilation(document, mockManager, mockFolders, mockLogger);
+    const result = await handleCompilation(document, mockManager, mockFolders, defaultSettings, mockLogger);
 
     expect(result.errors).toBeUndefined();
     expect(typeof result.result).toBe("string");
@@ -41,7 +41,7 @@ describe("Compilation Handler", () => {
 
   it("should add functions-only flag for stanfunctions", async () => {
     const document = createDocument("file:///functions.stanfunctions", "real f(real x) { return x * 2; }", "stan");
-    const result = await handleCompilation(document, mockManager, mockFolders, mockLogger);
+    const result = await handleCompilation(document, mockManager, mockFolders, defaultSettings, mockLogger);
 
     expect(result.errors).toBeUndefined();
     expect(typeof result.result).toBe("string");
@@ -49,7 +49,7 @@ describe("Compilation Handler", () => {
 
   it("should handle compilation errors", async () => {
     const document = createDocument("file:///error.stan", "invalid stan code");
-    const result = await handleCompilation(document, mockManager, mockFolders, mockLogger);
+    const result = await handleCompilation(document, mockManager, mockFolders, defaultSettings, mockLogger);
 
     expect(Array.isArray(result.errors)).toBe(true);
     expect(result.result).toBeUndefined();

--- a/src/__tests__/handlers/includes.test.ts
+++ b/src/__tests__/handlers/includes.test.ts
@@ -6,6 +6,7 @@ import { handleIncludes, setFileSystemReader } from "../../handlers/compilation/
 import { promises } from "fs";
 
 describe("Includes Handler", () => {
+
   const createMockDocument = (uri: string, content: string): TextDocument => {
     return TextDocument.create(uri, "stan", 1, content);
   };
@@ -37,7 +38,7 @@ describe("Includes Handler", () => {
       const documentManager = createMockDocumentManager();
       const workspaceFolders = createMockWorkspaceFolders();
 
-      const result = await handleIncludes(document, documentManager, workspaceFolders, mockLogger);
+      const result = await handleIncludes(document, documentManager, workspaceFolders, [], mockLogger);
 
       expect(result).toEqual({});
     });
@@ -58,7 +59,7 @@ describe("Includes Handler", () => {
       const documentManager = createMockDocumentManager([includeDocument]);
       const workspaceFolders = createMockWorkspaceFolders();
 
-      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, mockLogger);
+      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders,[], mockLogger);
 
       expect(result).toEqual({
         [includeFilename]: includeContent
@@ -85,7 +86,7 @@ describe("Includes Handler", () => {
       const documentManager = createMockDocumentManager(includeDocuments);
       const workspaceFolders = createMockWorkspaceFolders();
 
-      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, mockLogger);
+      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders,[], mockLogger);
 
       const expected = Object.fromEntries(includes.map((filename, index) => [filename, contents[index]!]));
       expect(result).toEqual(expected);
@@ -113,7 +114,7 @@ describe("Includes Handler", () => {
       const mockReadFile = spyOn(promises, "readFile").mockResolvedValue(filesystemContent);
 
       try {
-        const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, mockLogger);
+        const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
 
         // Should use workspace version, NOT filesystem version
         expect(result).toEqual({
@@ -146,7 +147,7 @@ describe("Includes Handler", () => {
       const mockReadFile = spyOn(promises, "readFile").mockResolvedValue(filesystemContent);
 
       try {
-        const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, mockLogger);
+        const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
 
         // Should use filesystem version since workspace had nothing
         expect(result).toEqual({
@@ -180,7 +181,7 @@ describe("Includes Handler", () => {
       const documentManager = createMockDocumentManager([includeDocument]);
       const workspaceFolders = createMockWorkspaceFolders();
 
-      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, mockLogger);
+      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
 
       expect(result).toEqual({
         [includeFilename]: includeContent
@@ -204,7 +205,7 @@ describe("Includes Handler", () => {
       const workspaceFolders = createMockWorkspaceFolders();
 
       const startTime = Date.now();
-      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, mockLogger);
+      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
       const endTime = Date.now();
 
       // Should complete quickly (concurrent resolution)
@@ -230,7 +231,7 @@ describe("Includes Handler", () => {
       const documentManager = createMockDocumentManager([includeDocument]);
       const workspaceFolders = createMockWorkspaceFolders();
 
-      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, mockLogger);
+      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
 
       // Verify return type structure
       expect(typeof result).toBe("object");
@@ -259,7 +260,7 @@ describe("Includes Handler", () => {
       const documentManager = createMockDocumentManager();
       const workspaceFolders = createMockWorkspaceFolders();
 
-      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, mockLogger);
+      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
 
       expect(result).toEqual({});
     });
@@ -273,7 +274,7 @@ describe("Includes Handler", () => {
       const documentManager = createMockDocumentManager();
       const workspaceFolders: WorkspaceFolder[] = []; // Empty workspace folders
 
-      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, mockLogger);
+      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
 
       expect(result).toEqual({});
     });
@@ -287,7 +288,7 @@ describe("Includes Handler", () => {
       const documentManager = createMockDocumentManager();
       const workspaceFolders = createMockWorkspaceFolders();
 
-      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, mockLogger);
+      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
 
       expect(result).toEqual({});
     });

--- a/src/handlers/compilation/compilation.ts
+++ b/src/handlers/compilation/compilation.ts
@@ -13,6 +13,10 @@ export interface Settings {
   maxLineLength: number;
   includePaths: string[];
 }
+// todo?: warnPedantic: boolean;
+//    would require the callers specify a purpose, since no pedantic warnings
+//    are currently generated when the auto-format flag is used
+
 export const defaultSettings: Settings = {
   maxLineLength: 78,
   includePaths: [],

--- a/src/handlers/compilation/compilation.ts
+++ b/src/handlers/compilation/compilation.ts
@@ -9,14 +9,22 @@ import { stanc } from "../../stanc/compiler";
 import type { StancReturn } from "../../types/common";
 import { URI } from "vscode-uri";
 
+export interface Settings {
+  maxLineLength: number;
+  includePaths: string[];
+}
+export const defaultSettings: Settings = {
+  maxLineLength: 78,
+  includePaths: [],
+};
+
 export async function handleCompilation(
   document: TextDocument,
   documentManager: TextDocuments<TextDocument>,
   workspaceFolders: WorkspaceFolder[],
+  settings: Settings,
   logger: RemoteConsole
 ): Promise<StancReturn> {
-  const lineLength = 78; // TODO make this configurable
-
   const filename = URI.parse(document.uri).fsPath;
   const code = document.getText();
 
@@ -24,12 +32,13 @@ export async function handleCompilation(
     document,
     documentManager,
     workspaceFolders,
+    settings.includePaths,
     logger
   );
   const stanc_args = [
     "auto-format",
     `filename-in-msg=${filename}`,
-    `max-line-length=${lineLength}`,
+    `max-line-length=${settings.maxLineLength}`,
     "canonicalze=deprecations",
     "allow-undefined",
   ];

--- a/src/handlers/diagnostics.ts
+++ b/src/handlers/diagnostics.ts
@@ -1,20 +1,20 @@
 import {
-    Diagnostic,
-    DiagnosticSeverity,
-    Range,
-    TextDocuments,
-    WorkspaceFolder,
-    type DocumentDiagnosticParams,
-    type RemoteConsole,
+  Diagnostic,
+  DiagnosticSeverity,
+  Range,
+  TextDocuments,
+  WorkspaceFolder,
+  type DocumentDiagnosticParams,
+  type RemoteConsole,
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { provideDiagnostics } from "../language/diagnostics";
 import type {
-    Range as DomainRange,
-    DiagnosticSeverity as DomainSeverity,
-    StanDiagnostic,
+  Range as DomainRange,
+  DiagnosticSeverity as DomainSeverity,
+  StanDiagnostic,
 } from "../types/diagnostics";
-import { handleCompilation } from "./compilation/compilation";
+import { handleCompilation, type Settings } from "./compilation/compilation";
 
 function stanDiagnosticToLspDiagnostic(stanDiag: StanDiagnostic): Diagnostic {
   return {
@@ -39,7 +39,7 @@ function domainRangeToLspRange(domainRange: DomainRange): Range {
 }
 
 function domainSeverityToLspSeverity(
-  domainSeverity: DomainSeverity,
+  domainSeverity: DomainSeverity
 ): DiagnosticSeverity {
   switch (domainSeverity) {
     case 1:
@@ -59,7 +59,8 @@ export async function handleDiagnostics(
   params: DocumentDiagnosticParams,
   documents: TextDocuments<TextDocument>,
   workspaceFolders: WorkspaceFolder[],
-  logger: RemoteConsole,
+  settings: Settings,
+  logger: RemoteConsole
 ): Promise<Diagnostic[]> {
   const document = documents.get(params.textDocument.uri);
   if (!document) {
@@ -70,6 +71,7 @@ export async function handleDiagnostics(
     document,
     documents,
     workspaceFolders,
+    settings,
     logger
   );
   const stanDiagnostics = provideDiagnostics(compilerResult);

--- a/src/handlers/formatting.ts
+++ b/src/handlers/formatting.ts
@@ -6,12 +6,13 @@ import type {
   WorkspaceFolder,
 } from "vscode-languageserver";
 import type { TextDocument } from "vscode-languageserver-textdocument";
-import { handleCompilation } from "./compilation/compilation";
+import { handleCompilation, type Settings } from "./compilation/compilation";
 
 export async function handleFormatting(
   params: DocumentFormattingParams,
   documents: TextDocuments<TextDocument>,
   workspaceFolders: WorkspaceFolder[],
+  settings: Settings,
   logger: RemoteConsole
 ): Promise<TextEdit[] | { errors: string[] }> {
   const document = documents.get(params.textDocument.uri);
@@ -22,6 +23,7 @@ export async function handleFormatting(
     document,
     documents,
     workspaceFolders,
+    settings,
     logger
   );
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,6 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
 import {
+  DiagnosticRefreshRequest,
   DidChangeConfigurationNotification,
   TextDocumentSyncKind,
   TextDocuments,
@@ -88,6 +89,8 @@ const startLanguageServer = (
         (change.settings["stan-language-server"] || defaultSettings)
       );
     }
+
+    connection.sendRequest(DiagnosticRefreshRequest.type, undefined);
   });
 
   function getDocumentSettings(resource: string): Thenable<Settings> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import {
   DiagnosticRefreshRequest,
   DidChangeConfigurationNotification,
+  DocumentDiagnosticRequest,
   TextDocumentSyncKind,
   TextDocuments,
   type Connection,
@@ -18,7 +19,10 @@ import {
   setFileSystemReader,
   type FileSystemReader,
 } from "../handlers/compilation/includes.ts";
-import { defaultSettings, type Settings } from "../handlers/compilation/compilation.ts";
+import {
+  defaultSettings,
+  type Settings,
+} from "../handlers/compilation/compilation.ts";
 
 const startLanguageServer = (
   connection: Connection,
@@ -74,7 +78,6 @@ const startLanguageServer = (
     connection.console.info("Stan language server is exiting...");
   });
 
-
   let globalSettings: Settings = defaultSettings;
 
   // Cache the settings of all open documents
@@ -114,7 +117,7 @@ const startLanguageServer = (
     return handleCompletion(params, documents);
   });
 
-  connection.onRequest("textDocument/diagnostic", async (params) => {
+  connection.onRequest(DocumentDiagnosticRequest.method, async (params) => {
     const folders = (await connection.workspace.getWorkspaceFolders()) || [];
     const settings = await getDocumentSettings(params.textDocument.uri);
     return {


### PR DESCRIPTION
Closes #45.

Builds on #47 because I wanted stanc to live in one central call site in order to make this easier.

More or less directly taken from [the guide](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#using-configuration-settings-in-the-server)