### PR TITLE
Pass optional FileSystemReader instead of mutating global variable

### DIFF
--- a/src/__tests__/handlers/includes.test.ts
+++ b/src/__tests__/handlers/includes.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach, spyOn, mock } from "bun:test";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { TextDocuments, WorkspaceFolder } from "vscode-languageserver";
 import type { RemoteConsole } from "vscode-languageserver";
-import { handleIncludes, setFileSystemReader } from "../../handlers/compilation/includes";
+import { handleIncludes } from "../../handlers/compilation/includes";
 import { promises } from "fs";
 
 describe("Includes Handler", () => {
@@ -25,7 +25,7 @@ describe("Includes Handler", () => {
 
   beforeEach(() => {
     mockLogger = {
-      warn: mock(() => {}),
+      warn: mock(() => { }),
     } as any;
   });
 
@@ -59,7 +59,7 @@ describe("Includes Handler", () => {
       const documentManager = createMockDocumentManager([includeDocument]);
       const workspaceFolders = createMockWorkspaceFolders();
 
-      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders,[], mockLogger);
+      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
 
       expect(result).toEqual({
         [includeFilename]: includeContent
@@ -86,7 +86,7 @@ describe("Includes Handler", () => {
       const documentManager = createMockDocumentManager(includeDocuments);
       const workspaceFolders = createMockWorkspaceFolders();
 
-      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders,[], mockLogger);
+      const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
 
       const expected = Object.fromEntries(includes.map((filename, index) => [filename, contents[index]!]));
       expect(result).toEqual(expected);
@@ -137,7 +137,7 @@ describe("Includes Handler", () => {
         '#include "config.stan"\nparameters { real x; } model { x ~ normal(0, 1); }'
       );
 
-      setFileSystemReader((filename: string) => promises.readFile(filename, "utf-8"));
+      const reader = (filename: string) => promises.readFile(filename, "utf-8");
 
       // Empty document manager (no workspace documents)
       const documentManager = createMockDocumentManager([]);
@@ -147,7 +147,7 @@ describe("Includes Handler", () => {
       const mockReadFile = spyOn(promises, "readFile").mockResolvedValue(filesystemContent);
 
       try {
-        const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
+        const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger, reader);
 
         // Should use filesystem version since workspace had nothing
         expect(result).toEqual({

--- a/src/handlers/compilation/compilation.ts
+++ b/src/handlers/compilation/compilation.ts
@@ -6,7 +6,7 @@ import {
 } from "vscode-languageserver";
 import { handleIncludes } from "./includes";
 import { stanc } from "../../stanc/compiler";
-import type { StancReturn } from "../../types/common";
+import type { FileSystemReader, StancReturn } from "../../types/common";
 import { URI } from "vscode-uri";
 
 export interface Settings {
@@ -27,7 +27,8 @@ export async function handleCompilation(
   documentManager: TextDocuments<TextDocument>,
   workspaceFolders: WorkspaceFolder[],
   settings: Settings,
-  logger: RemoteConsole
+  logger: RemoteConsole,
+  reader?: FileSystemReader
 ): Promise<StancReturn> {
   const filename = URI.parse(document.uri).fsPath;
   const code = document.getText();
@@ -37,7 +38,8 @@ export async function handleCompilation(
     documentManager,
     workspaceFolders,
     settings.includePaths,
-    logger
+    logger,
+    reader
   );
   const stanc_args = [
     "auto-format",

--- a/src/handlers/compilation/includes.ts
+++ b/src/handlers/compilation/includes.ts
@@ -137,13 +137,6 @@ const readIncludedFileFromWorkspace = (
   return Promise.resolve(includedFile.getText());
 };
 
-// export type FileSystemReader = (filename: Filename) => Promise<FileContent>;
-// let fileSystemReader: FileSystemReader | undefined = undefined;
-
-// export const setFileSystemReader = (reader: FileSystemReader) => {
-//   fileSystemReader = reader;
-// };
-
 const readIncludedFileFromFileSystem = async (
   filename: Filename,
   dirs: string[],

--- a/src/handlers/diagnostics.ts
+++ b/src/handlers/diagnostics.ts
@@ -15,6 +15,7 @@ import type {
   StanDiagnostic,
 } from "../types/diagnostics";
 import { handleCompilation, type Settings } from "./compilation/compilation";
+import type { FileSystemReader } from "../types";
 
 function stanDiagnosticToLspDiagnostic(stanDiag: StanDiagnostic): Diagnostic {
   return {
@@ -60,7 +61,8 @@ export async function handleDiagnostics(
   documents: TextDocuments<TextDocument>,
   workspaceFolders: WorkspaceFolder[],
   settings: Settings,
-  logger: RemoteConsole
+  logger: RemoteConsole,
+  reader?: FileSystemReader
 ): Promise<Diagnostic[]> {
   const document = documents.get(params.textDocument.uri);
   if (!document) {
@@ -72,7 +74,8 @@ export async function handleDiagnostics(
     documents,
     workspaceFolders,
     settings,
-    logger
+    logger,
+    reader
   );
   const stanDiagnostics = provideDiagnostics(compilerResult);
 

--- a/src/handlers/formatting.ts
+++ b/src/handlers/formatting.ts
@@ -7,13 +7,15 @@ import type {
 } from "vscode-languageserver";
 import type { TextDocument } from "vscode-languageserver-textdocument";
 import { handleCompilation, type Settings } from "./compilation/compilation";
+import type { FileSystemReader } from "../types";
 
 export async function handleFormatting(
   params: DocumentFormattingParams,
   documents: TextDocuments<TextDocument>,
   workspaceFolders: WorkspaceFolder[],
   settings: Settings,
-  logger: RemoteConsole
+  logger: RemoteConsole,
+  reader?: FileSystemReader
 ): Promise<TextEdit[] | { errors: string[] }> {
   const document = documents.get(params.textDocument.uri);
   if (!document) {
@@ -24,7 +26,8 @@ export async function handleFormatting(
     documents,
     workspaceFolders,
     settings,
-    logger
+    logger,
+    reader
   );
 
   if (result.errors && result.errors.length > 0) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -137,7 +137,8 @@ const startLanguageServer = (
         documents,
         folders,
         settings,
-        connection.console
+        connection.console,
+        reader
       ),
     };
   });
@@ -150,7 +151,8 @@ const startLanguageServer = (
       documents,
       folders,
       settings,
-      connection.console
+      connection.console,
+      reader
     );
     if (Array.isArray(formattingResult)) {
       return formattingResult;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -16,9 +16,8 @@ import {
   handleHover,
 } from "../handlers/index.ts";
 import {
-  setFileSystemReader,
   type FileSystemReader,
-} from "../handlers/compilation/includes.ts";
+} from "../types/common.ts";
 import {
   defaultSettings,
   type Settings,
@@ -171,10 +170,6 @@ const startLanguageServer = (
     }
     return handleHover(document, params);
   });
-
-  if (reader) {
-    setFileSystemReader(reader);
-  }
 
   documents.listen(connection);
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,3 +1,5 @@
+import type { FileContent, Filename } from "../handlers/compilation/includes";
+
 export interface Position {
   line: number;
   character: number;
@@ -23,3 +25,5 @@ export type StancFunction = (
   options: string[],
   includes?: Record<string, string>,
 ) => StancReturn;
+
+export type FileSystemReader = (filename: Filename) => Promise<FileContent>;


### PR DESCRIPTION
@WardBrian This gets rid of the global `reader` variable which is mutated when a file system reader is present and instead just passes the `FileSystemReader`. Makes the code easier to reason about and is coherent with the functional programming style I strive for.