### PR TITLE
Make settings functionality more robust to different inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,19 @@ bun build server.ts --compile --outfile stan-language-server
 
 ```json
 {
-    "clients": {
-        "stan-lsp": {
-            "enabled": true,
-            "command": ["/YOUR/PATH/TO/stan-language-server"], 
-            "selector": "source.stan | source.stanfunctions",
-            "initializationOptions": {}
-        }
+  "clients": {
+    "stan-lsp": {
+      "enabled": true,
+      "command": ["/YOUR/PATH/TO/stan-language-server"],
+      "selector": "source.stan | source.stanfunctions",
+      "initializationOptions": {},
+      "settings": {
+        "stan-language-server": { "includePaths": [], "maxLineLength": 78 }
+      }
     }
+  }
 }
+
 ```
 
 ### Emacs (eglot)
@@ -49,6 +53,6 @@ bun build server.ts --compile --outfile stan-language-server
 Assuming you are using stan-ts-mode:
 ```elisp
 (with-eval-after-load 'eglot
-    (add-to-list 'eglot-server-programs 
-        '(stan-ts-mode . ("/YOUR/PATH/TO/stan-language-server"))))
+    (add-to-list 'eglot-server-programs
+      '((stan-ts-mode) "/YOUR/PATH/TO/stan-language-server")))
 ```

--- a/src/__tests__/handlers/diagnostics.test.ts
+++ b/src/__tests__/handlers/diagnostics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { DiagnosticSeverity as LspDiagnosticSeverity } from "vscode-languageserver";
 import { DiagnosticSeverity as DomainSeverity } from "../../types/diagnostics";
 import { provideDiagnostics } from "../../language/diagnostics";
+import { SERVER_ID } from "../../constants";
 
 // Test compiler results for diagnostic provider tests
 const successfulCompileWithWarnings = {
@@ -85,8 +85,10 @@ describe("Diagnostic Handler Components", () => {
 
       const diagnostic = result[0]!;
       expect(diagnostic.severity).toBe(DomainSeverity.Warning);
-      expect(diagnostic.message).toBe("Variable name 'jacobian' will be a reserved word starting in Stan 2.38.0. Please rename it!");
-      expect(diagnostic.source).toBe("stan-language-server");
+      expect(diagnostic.message).toBe(
+        "Variable name 'jacobian' will be a reserved word starting in Stan 2.38.0. Please rename it!"
+      );
+      expect(diagnostic.source).toBe(SERVER_ID);
 
       // Check range (0-indexed)
       expect(diagnostic.range.start.line).toBe(0);
@@ -103,8 +105,10 @@ describe("Diagnostic Handler Components", () => {
 
       const firstError = result[0]!;
       expect(firstError.severity).toBe(DomainSeverity.Error);
-      expect(firstError.message).toBe("(Transformed) Parameters cannot be integers.");
-      expect(firstError.source).toBe("stan-language-server");
+      expect(firstError.message).toBe(
+        "(Transformed) Parameters cannot be integers."
+      );
+      expect(firstError.source).toBe(SERVER_ID);
 
       // Check single line, multi-column range (0-indexed)
       expect(firstError.range.start.line).toBe(2);

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const SERVER_ID = "stan-language-server";

--- a/src/handlers/diagnostics.ts
+++ b/src/handlers/diagnostics.ts
@@ -16,13 +16,14 @@ import type {
 } from "../types/diagnostics";
 import { handleCompilation, type Settings } from "./compilation/compilation";
 import type { FileSystemReader } from "../types";
+import { SERVER_ID } from "../constants";
 
 function stanDiagnosticToLspDiagnostic(stanDiag: StanDiagnostic): Diagnostic {
   return {
     range: domainRangeToLspRange(stanDiag.range),
     severity: domainSeverityToLspSeverity(stanDiag.severity),
     message: stanDiag.message,
-    source: stanDiag.source ?? "stan-language-server",
+    source: stanDiag.source ?? SERVER_ID,
   };
 }
 

--- a/src/language/diagnostics/provider.ts
+++ b/src/language/diagnostics/provider.ts
@@ -5,6 +5,7 @@ import {
   getWarningMessage,
   getErrorMessage,
 } from "./linter";
+import { SERVER_ID } from "../../constants";
 
 
 export function provideDiagnostics(compilerResult: StancReturn): StanDiagnostic[] {
@@ -18,7 +19,7 @@ export function provideDiagnostics(compilerResult: StancReturn): StanDiagnostic[
           range,
           severity: DiagnosticSeverity.Error,
           message: getErrorMessage(error),
-          source: "stan-language-server",
+          source: SERVER_ID,
         });
       }
     }
@@ -31,7 +32,7 @@ export function provideDiagnostics(compilerResult: StancReturn): StanDiagnostic[
           range,
           severity: DiagnosticSeverity.Warning,
           message: getWarningMessage(warning),
-          source: "stan-language-server",
+          source: SERVER_ID,
         });
       }
     }


### PR DESCRIPTION
Not sure if this would resolve #57 or not, but it's certainly a good idea. 

This handles the cases where clients send partial settings or no setting at all, which will be particularly important if we ever want to add a new setting one day that not all clients would be aware of.