### PR TITLE
Show notification when formatting fails due to errors

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -165,7 +165,7 @@ const startLanguageServer = (
       }
       connection.sendNotification("window/showMessage", {
         type: MessageType.Error,
-        message: `Formatting failed due to errors: ${formattingResult.errors.join(", ")}`,
+        message: "Formatting failed due to compile errors. See diagnostics for details.",
       });
       return [];
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ import {
   DiagnosticRefreshRequest,
   DidChangeConfigurationNotification,
   DocumentDiagnosticRequest,
+  MessageType,
   TextDocumentSyncKind,
   TextDocuments,
   type Connection,
@@ -162,6 +163,10 @@ const startLanguageServer = (
       for (const error of formattingResult.errors) {
         connection.console.error(error);
       }
+      connection.sendNotification("window/showMessage", {
+        type: MessageType.Error,
+        message: `Formatting failed due to errors: ${formattingResult.errors.join(", ")}`,
+      });
       return [];
     }
   });


### PR DESCRIPTION
@WardBrian When the user requests a document to be formatted that has compile errors, a notification window is shown with the errors instead of just logging the errors.