### PR TITLE
Re-use maps created for hover documentation, avoid whitespace bug

### DIFF
--- a/src/handlers/completion.ts
+++ b/src/handlers/completion.ts
@@ -83,17 +83,13 @@ function convertPosition(position: { line: number; character: number }): Positio
 }
 
 // Get distributions data
-function getDistributionData(): string[] {
-  return dump_stan_math_distributions()
-    .split("\n")
-    .map((line) => line.split(":")[0]?.trim() ?? "")
-    .filter((name) => name !== "");
-}
+const DISTRIBUTION_DATA = dump_stan_math_distributions()
+  .split("\n")
+  .map((line) => line.split(":")[0]?.trim() ?? "")
+  .filter((name) => name !== "");
 
 // Get function signatures data
-function getFunctionData(): string[] {
-  return dump_stan_math_signatures().split("\n");
-}
+const FUNCTION_DATA = dump_stan_math_signatures().split("\n");
 
 export function handleCompletion(
   params: CompletionParams,
@@ -109,9 +105,9 @@ export function handleCompletion(
 
   // Get completion items from all providers
   const keywords = provideKeywordCompletions(text, position);
-  const distributions = provideDistributionCompletions(text, position, getDistributionData());
+  const distributions = provideDistributionCompletions(text, position, DISTRIBUTION_DATA);
   const datatypes = provideDatatypeCompletions(text, position);
-  const functions = provideFunctionCompletions(text, position, getFunctionData());
+  const functions = provideFunctionCompletions(text, position, FUNCTION_DATA);
   const constraints = provideConstraintCompletions(text, position);
 
   // Convert all items to LSP format and combine

--- a/src/language/hover/distributions.ts
+++ b/src/language/hover/distributions.ts
@@ -1,7 +1,6 @@
 import { dump_stan_math_distributions } from "stanc3";
 import { isWhitespace } from "./util";
 
-
 const setupDistributionMap = () => {
   const distributionToFunctionMap: Map<string, string> = new Map();
   const mathDistributions = dump_stan_math_distributions();
@@ -14,8 +13,10 @@ const setupDistributionMap = () => {
     const extension = extensions.split(",", 1)[0]?.trim();
     distributionToFunctionMap.set(name, `${name}_${extension}`);
   }
-  return distributionToFunctionMap
+  return distributionToFunctionMap;
 };
+
+const DISTRIBUTION_FUNCTION_MAP = setupDistributionMap();
 
 const tildeBefore = (text: string, pos: number) => {
   for (let i = pos - 1; i >= 0; i--) {
@@ -34,13 +35,12 @@ const tildeBefore = (text: string, pos: number) => {
 export const tryDistributionHover = (
   text: string,
   beginningOfWord: number,
-  endOfWord: number,
+  endOfWord: number
 ): string | null => {
   if (!tildeBefore(text, beginningOfWord)) return null;
-  const distributionToFunctionMap = setupDistributionMap();
 
   const dist = text.substring(beginningOfWord, endOfWord).trim();
-  const functionName = distributionToFunctionMap.get(dist);
+  const functionName = DISTRIBUTION_FUNCTION_MAP.get(dist);
   if (!functionName) return null;
   return functionName;
 };

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -37,6 +37,27 @@ async def test_function_hover_outside_word(client: LanguageClient, character: in
         )
     assert results is None
 
+async def test_function_hover_whitespace_insensitive(client: LanguageClient):
+
+    code = """model {
+real foo =
+beta
+(1,2);
+}"""
+    with make_text_document(client, code) as test_uri:
+        results = await client.text_document_hover_async(
+            params=types.HoverParams(
+                position=types.Position(line=2, character=2),
+                text_document=types.TextDocumentIdentifier(uri=test_uri),
+            )
+        )
+
+    assert results is not None
+    assert (
+        "Jump to Stan Functions Reference index entry for beta"
+        in results.contents.value
+    )
+
 
 DISTRIBUTION_CODE = "model { foo ~ std_normal(); }"
 


### PR DESCRIPTION
Closes #67 

This also fixes a bug/premature optimization that was searching for a `(` on the same line before providing hover. Stan is whitespace insensitive, so this was wrong, as 

```stan
beta
( 1, 2 );
```
is a perfectly legitimate function call.