### PR TITLE
Pin old pygls version for pytest-lsp

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/setup-python@v6
 
     - name: Install dependencies
-      run: pip install pytest pytest-lsp
+      run: pip install pytest "pytest-lsp==0.4.3" "pygls<2"
 
     - name: Run tests
       run: pytest tests --verbose


### PR DESCRIPTION
This pinning will become unnecessary after https://github.com/swyddfa/lsp-devtools/issues/212