### PR TITLE
Bump stanc3 to fix node import issue

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "stan-language-server",
       "dependencies": {
-        "stanc3": "2.39.0",
+        "stanc3": "2.39.1",
         "trie-search": "2.2.1",
         "vscode-languageserver": "9.0.1",
         "vscode-languageserver-textdocument": "1.0.12",
@@ -208,7 +208,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "stanc3": ["stanc3@2.39.0", "", {}, "sha512-HKbus7PqzOGE4ZfkC6jAQ15U6UEtnMbRNvvqeVWj67NHphrMCoGLrlU1+nqkBPLfAHCWo1Xlap/ZSEefi1Nf9g=="],
+    "stanc3": ["stanc3@2.39.1", "", {}, "sha512-Guyf/g9pmaJZjj6lg9YLURpsOlnf802YOaVe9KGgoACaY2bPiyb+cYQdI4kfMciIHKHLp8Y9VN5Oh2eUV0OQaw=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "web-tree-sitter": "0.26.9"
   },
   "dependencies": {
-    "stanc3": "2.39.0",
+    "stanc3": "2.39.1",
     "trie-search": "2.2.1",
     "vscode-languageserver": "9.0.1",
     "vscode-languageserver-textdocument": "1.0.12",


### PR DESCRIPTION
This was a minor patch (https://github.com/WardBrian/npm-stanc3js/commit/1807f5a2adbffca268915a2c689a7bace9c81249) in the stanc3 npm package to hopefully resolve https://github.com/WardBrian/vscode-stan-extension/issues/41