### PR TITLE
Add server-owned document store

### DIFF
--- a/src/__tests__/server/document_state.test.ts
+++ b/src/__tests__/server/document_state.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenTextDocumentParams,
+} from "vscode-languageserver/node";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  changeDocument,
+  closeDocument,
+  emptyDocumentState,
+  openDocument,
+  type DocumentChange,
+  type DocumentState,
+  type DocumentTransition,
+} from "../../server/document_state";
+
+const uri = "file:///workspace/model.stan";
+
+const openParams = (
+  text = "abcdef",
+  version = 1,
+  documentUri = uri,
+): DidOpenTextDocumentParams => ({
+  textDocument: {
+    uri: documentUri,
+    languageId: "stan",
+    version,
+    text,
+  },
+});
+
+const closeParams = (documentUri = uri): DidCloseTextDocumentParams => ({
+  textDocument: { uri: documentUri },
+});
+
+const openedState = (text = "abcdef", version = 1): DocumentState => {
+  const transition = openDocument(emptyDocumentState(), openParams(text, version));
+  if (!transition.accepted) {
+    throw new Error(`Expected open transition, got ${transition.reason}`);
+  }
+  return transition.state;
+};
+
+describe("document state", () => {
+  it("opens and closes a document without mutating prior states", () => {
+    const emptyState = emptyDocumentState();
+    const document = TextDocument.create(uri, "stan", 1, "abcdef");
+    const expectedOpened: DocumentTransition<TextDocument> = {
+      accepted: true,
+      state: new Map([[uri, document]]),
+      value: document,
+    };
+    const expectedClosed: DocumentTransition<TextDocument> = {
+      accepted: true,
+      state: new Map(),
+      value: document,
+    };
+
+    const opened = openDocument(emptyState, openParams());
+    expect(opened.accepted).toBeTrue();
+    expect(opened).toEqual(expectedOpened);
+    expect(emptyState.size).toBe(0);
+    expect(opened.state.get(uri)?.getText()).toBe("abcdef");
+
+    const closed = closeDocument(opened.state, closeParams());
+    expect(closed.accepted).toBeTrue();
+    expect(closed).toEqual(expectedClosed);
+    expect(opened.state.has(uri)).toBeTrue();
+    expect(closed.state.has(uri)).toBeFalse();
+  });
+
+  it("applies multiple ranged changes in order", () => {
+    const state = openedState();
+    const contentChanges: DidChangeTextDocumentParams["contentChanges"] = [
+      {
+        range: {
+          start: { line: 0, character: 1 },
+          end: { line: 0, character: 3 },
+        },
+        text: "X",
+      },
+      {
+        range: {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 4 },
+        },
+        text: "Y",
+      },
+    ];
+    const params: DidChangeTextDocumentParams = {
+      textDocument: { uri, version: 2 },
+      contentChanges,
+    };
+    const expectedPreviousDocument = TextDocument.create(
+      uri,
+      "stan",
+      1,
+      "abcdef",
+    );
+    const expectedValue: DocumentChange = {
+      previousDocument: expectedPreviousDocument,
+      document: TextDocument.update(
+        TextDocument.create(
+          expectedPreviousDocument.uri,
+          expectedPreviousDocument.languageId,
+          expectedPreviousDocument.version,
+          expectedPreviousDocument.getText(),
+        ),
+        contentChanges,
+        2,
+      ),
+      contentChanges,
+    };
+
+    const transition = changeDocument(state, params);
+    expect(transition.accepted).toBeTrue();
+    if (!transition.accepted) {
+      throw new Error(`Expected change transition, got ${transition.reason}`);
+    }
+
+    expect(state.get(uri)?.getText()).toBe("abcdef");
+    expect(transition.value).toEqual(expectedValue);
+    expect(transition.state.get(uri)?.getText()).toBe("aXYf");
+  });
+
+  it("applies full-document replacements", () => {
+    const transition = changeDocument(openedState(), {
+      textDocument: { uri, version: 2 },
+      contentChanges: [{ text: "parameters { real x; }" }],
+    });
+
+    expect(transition.accepted).toBeTrue();
+    expect(transition.state.get(uri)?.getText()).toBe("parameters { real x; }");
+    expect(transition.state.get(uri)?.version).toBe(2);
+  });
+
+  it("preserves raw changes independently of notification objects", () => {
+    const params: DidChangeTextDocumentParams = {
+      textDocument: { uri, version: 2 },
+      contentChanges: [{
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 1 },
+        },
+        text: "A",
+      }],
+    };
+    const transition = changeDocument(openedState(), params);
+    if (!transition.accepted) {
+      throw new Error(`Expected change transition, got ${transition.reason}`);
+    }
+
+    const inputChange = params.contentChanges[0];
+    if (inputChange && "range" in inputChange) {
+      inputChange.range.start.character = 5;
+      inputChange.text = "changed later";
+    }
+
+    expect(transition.value.contentChanges).toEqual([{
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 1 },
+      },
+      text: "A",
+    }]);
+  });
+
+  it("rejects invalid transitions without replacing state", () => {
+    const emptyState = emptyDocumentState();
+    const unknownChange = changeDocument(emptyState, {
+      textDocument: { uri, version: 1 },
+      contentChanges: [{ text: "unknown" }],
+    });
+    expect(unknownChange).toEqual({
+      accepted: false,
+      state: emptyState,
+      reason: "not-open",
+    });
+    expect(closeDocument(emptyState, closeParams())).toMatchObject({
+      accepted: false,
+      reason: "not-open",
+    });
+    expect(openDocument(emptyState, openParams("invalid", 1.5))).toMatchObject({
+      accepted: false,
+      reason: "invalid-version",
+    });
+
+    const state = openedState("original", 3);
+    expect(openDocument(state, openParams("duplicate", 4))).toMatchObject({
+      accepted: false,
+      reason: "already-open",
+    });
+    expect(changeDocument(state, {
+      textDocument: { uri, version: 3 },
+      contentChanges: [{ text: "stale" }],
+    })).toMatchObject({ accepted: false, reason: "stale-version" });
+    expect(changeDocument(state, {
+      textDocument: { uri, version: 4 },
+      contentChanges: [],
+    })).toMatchObject({ accepted: false, reason: "empty-change" });
+    expect(changeDocument(state, {
+      textDocument: { uri, version: undefined },
+      contentChanges: [{ text: "missing version" }],
+    } as unknown as DidChangeTextDocumentParams)).toMatchObject({
+      accepted: false,
+      reason: "invalid-version",
+    });
+
+    expect(state.get(uri)?.getText()).toBe("original");
+    expect(state.get(uri)?.version).toBe(3);
+  });
+
+  it("keeps document transitions independent by URI", () => {
+    const otherUri = "file:///workspace/other.stan";
+    const firstDocument = TextDocument.create(uri, "stan", 1, "one");
+    const secondDocument = TextDocument.create(otherUri, "stan", 7, "two");
+    const contentChanges: DidChangeTextDocumentParams["contentChanges"] = [
+      { text: "changed" },
+    ];
+    const changedDocument = TextDocument.update(
+      TextDocument.create(
+        firstDocument.uri,
+        firstDocument.languageId,
+        firstDocument.version,
+        firstDocument.getText(),
+      ),
+      contentChanges,
+      2,
+    );
+    const expectedChanged: DocumentTransition<DocumentChange> = {
+      accepted: true,
+      state: new Map([
+        [uri, changedDocument],
+        [otherUri, secondDocument],
+      ]),
+      value: {
+        previousDocument: firstDocument,
+        document: changedDocument,
+        contentChanges,
+      },
+    };
+    const expectedClosed: DocumentTransition<TextDocument> = {
+      accepted: true,
+      state: new Map([[uri, changedDocument]]),
+      value: secondDocument,
+    };
+
+    const first = openDocument(emptyDocumentState(), openParams("one", 1));
+    const second = openDocument(first.state, openParams("two", 7, otherUri));
+    const changed = changeDocument(second.state, {
+      textDocument: { uri, version: 2 },
+      contentChanges,
+    });
+    const closed = closeDocument(changed.state, closeParams(otherUri));
+
+    expect(changed).toEqual(expectedChanged);
+    expect(closed).toEqual(expectedClosed);
+    expect(closed.state.get(uri)?.getText()).toBe("changed");
+    expect(closed.state.get(uri)?.version).toBe(2);
+    expect(closed.state.has(otherUri)).toBeFalse();
+    expect(changed.state.has(otherUri)).toBeTrue();
+  });
+});

--- a/src/handlers/compilation/compilation.ts
+++ b/src/handlers/compilation/compilation.ts
@@ -1,11 +1,10 @@
 import type { TextDocument } from "vscode-languageserver-textdocument";
 import {
-  type TextDocuments,
   type WorkspaceFolder,
   type RemoteConsole,
 } from "vscode-languageserver";
 import { handleIncludes } from "./includes";
-import type { FileSystemReader } from "../../types/common";
+import type { FileSystemReader, TextDocumentProvider } from "../../types/common";
 import { URI } from "vscode-uri";
 import { stanc, type StancReturn } from "stanc3";
 
@@ -25,7 +24,7 @@ export type Purpose = "formatting" | "linting";
 
 export async function handleCompilation(
   document: TextDocument,
-  documentManager: TextDocuments<TextDocument>,
+  documentManager: TextDocumentProvider,
   workspaceFolders: WorkspaceFolder[],
   settings: Settings,
   purpose: Purpose,

--- a/src/handlers/compilation/includes.ts
+++ b/src/handlers/compilation/includes.ts
@@ -1,12 +1,11 @@
 import {
-  TextDocuments,
   WorkspaceFolder,
   type RemoteConsole,
 } from "vscode-languageserver";
 import { join } from "path";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { URI, Utils } from "vscode-uri";
-import type { FileSystemReader } from "../../types";
+import type { FileSystemReader, TextDocumentProvider } from "../../types";
 
 export type Filename = string;
 export type FileContent = string;
@@ -27,7 +26,7 @@ export function isFilePathError(value: unknown): value is FilePathError {
 
 export async function handleIncludes(
   document: TextDocument,
-  documentManager: TextDocuments<TextDocument>,
+  documentManager: TextDocumentProvider,
   workspaceFolders: WorkspaceFolder[],
   includePaths: string[],
   logger: RemoteConsole,
@@ -98,7 +97,7 @@ export async function handleIncludes(
 
 const readIncludedFile = async (
   document: TextDocument,
-  documentManager: TextDocuments<TextDocument>,
+  documentManager: TextDocumentProvider,
   workspaceFolders: WorkspaceFolder[],
   includePaths: string[],
   filename: Filename,
@@ -133,7 +132,7 @@ const readIncludedFile = async (
 };
 
 const readIncludedFileFromWorkspace = (
-  documentManager: TextDocuments<TextDocument>,
+  documentManager: TextDocumentProvider,
   workspaceFolders: WorkspaceFolder[],
   filename: Filename,
   currentDir: URI

--- a/src/handlers/completion.ts
+++ b/src/handlers/completion.ts
@@ -1,10 +1,10 @@
 import {
   type CompletionParams,
-  TextDocuments,
   CompletionItem,
   CompletionItemKind,
 } from "vscode-languageserver";
-import { TextDocument, type Position } from "vscode-languageserver-textdocument";
+import { type Position } from "vscode-languageserver-textdocument";
+import type { TextDocumentProvider } from "../types/common";
 
 import TrieSearch from "trie-search";
 
@@ -85,7 +85,7 @@ export const getTextUpToCursor = (text: string, position: Position): string => {
 
 export function handleCompletion(
   { position, textDocument }: CompletionParams,
-  documents: TextDocuments<TextDocument>,
+  documents: TextDocumentProvider,
   supportsSnippets: boolean,
 ): CompletionItem[] {
   const document = documents.get(textDocument.uri);

--- a/src/handlers/diagnostics.ts
+++ b/src/handlers/diagnostics.ts
@@ -1,21 +1,20 @@
 import {
     Diagnostic,
-    DiagnosticSeverity, TextDocuments,
+    DiagnosticSeverity,
     WorkspaceFolder,
     type DocumentDiagnosticParams,
     type RemoteConsole
 } from "vscode-languageserver";
-import { TextDocument } from "vscode-languageserver-textdocument";
 import { SERVER_ID } from "../constants";
 import {
     provideDiagnostics
 } from "../language/diagnostics/provider";
-import type { FileSystemReader } from "../types";
+import type { FileSystemReader, TextDocumentProvider } from "../types";
 import { handleCompilation, type Settings } from "./compilation/compilation";
 
 export async function handleDiagnostics(
   params: DocumentDiagnosticParams,
-  documents: TextDocuments<TextDocument>,
+  documents: TextDocumentProvider,
   workspaceFolders: WorkspaceFolder[],
   settings: Settings,
   logger: RemoteConsole,

--- a/src/handlers/formatting.ts
+++ b/src/handlers/formatting.ts
@@ -1,17 +1,15 @@
 import type {
   DocumentFormattingParams,
   RemoteConsole,
-  TextDocuments,
   TextEdit,
   WorkspaceFolder,
 } from "vscode-languageserver";
-import type { TextDocument } from "vscode-languageserver-textdocument";
 import { handleCompilation, type Settings } from "./compilation/compilation";
-import type { FileSystemReader } from "../types";
+import type { FileSystemReader, TextDocumentProvider } from "../types";
 
 export async function handleFormatting(
   params: DocumentFormattingParams,
-  documents: TextDocuments<TextDocument>,
+  documents: TextDocumentProvider,
   workspaceFolders: WorkspaceFolder[],
   settings: Settings,
   logger: RemoteConsole,

--- a/src/server/document_state.ts
+++ b/src/server/document_state.ts
@@ -1,0 +1,130 @@
+import { TextDocument } from "vscode-languageserver-textdocument";
+import type {
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenTextDocumentParams,
+} from "vscode-languageserver/node";
+
+export type DocumentState = ReadonlyMap<string, TextDocument>;
+
+export type DocumentContentChange =
+  DidChangeTextDocumentParams["contentChanges"][number];
+
+export type DocumentChange = {
+  previousDocument: TextDocument;
+  document: TextDocument;
+  contentChanges: readonly DocumentContentChange[];
+};
+
+export type DocumentTransitionRejection =
+  | "already-open"
+  | "not-open"
+  | "invalid-version"
+  | "stale-version"
+  | "empty-change";
+
+export type DocumentTransition<T> =
+  | { accepted: true; state: DocumentState; value: T }
+  | {
+      accepted: false;
+      state: DocumentState;
+      reason: DocumentTransitionRejection;
+    };
+
+const cloneContentChange = (
+  change: DocumentContentChange,
+): DocumentContentChange => {
+  if (!("range" in change)) {
+    return { ...change };
+  }
+
+  return {
+    ...change,
+    range: {
+      start: { ...change.range.start },
+      end: { ...change.range.end },
+    },
+  };
+};
+
+export const emptyDocumentState = (): DocumentState => new Map();
+
+export const openDocument = (
+  state: DocumentState,
+  params: DidOpenTextDocumentParams,
+): DocumentTransition<TextDocument> => {
+  const item = params.textDocument;
+  if (!Number.isInteger(item.version)) {
+    return { accepted: false, state, reason: "invalid-version" };
+  }
+  if (state.has(item.uri)) {
+    return { accepted: false, state, reason: "already-open" };
+  }
+
+  const document = TextDocument.create(
+    item.uri,
+    item.languageId,
+    item.version,
+    item.text,
+  );
+  const nextState = new Map(state);
+  nextState.set(item.uri, document);
+
+  return { accepted: true, state: nextState, value: document };
+};
+
+export const changeDocument = (
+  state: DocumentState,
+  params: DidChangeTextDocumentParams,
+): DocumentTransition<DocumentChange> => {
+  const previousDocument = state.get(params.textDocument.uri);
+  const version = params.textDocument.version;
+  if (!previousDocument) {
+    return { accepted: false, state, reason: "not-open" };
+  }
+  if (!Number.isInteger(version)) {
+    return { accepted: false, state, reason: "invalid-version" };
+  }
+  if (version <= previousDocument.version) {
+    return { accepted: false, state, reason: "stale-version" };
+  }
+  if (params.contentChanges.length === 0) {
+    return { accepted: false, state, reason: "empty-change" };
+  }
+
+  const contentChanges = params.contentChanges.map(cloneContentChange);
+  const workingDocument = TextDocument.create(
+    previousDocument.uri,
+    previousDocument.languageId,
+    previousDocument.version,
+    previousDocument.getText(),
+  );
+  const document = TextDocument.update(
+    workingDocument,
+    contentChanges,
+    version,
+  );
+  const nextState = new Map(state);
+  nextState.set(document.uri, document);
+
+  return {
+    accepted: true,
+    state: nextState,
+    value: { previousDocument, document, contentChanges },
+  };
+};
+
+export const closeDocument = (
+  state: DocumentState,
+  params: DidCloseTextDocumentParams,
+): DocumentTransition<TextDocument> => {
+  const document = state.get(params.textDocument.uri);
+  if (!document) {
+    return { accepted: false, state, reason: "not-open" };
+  }
+
+  const nextState = new Map(state);
+  nextState.delete(document.uri);
+
+  return { accepted: true, state: nextState, value: document };
+};

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,7 +5,6 @@ import {
   DocumentDiagnosticRequest,
   MessageType,
   TextDocumentSyncKind,
-  TextDocuments,
   CompletionItemKind,
   type Connection,
   type InitializeParams,
@@ -30,6 +29,12 @@ import {
   type Settings,
 } from "../handlers/compilation/compilation.ts";
 import { SERVER_ID } from "../constants/index.ts";
+import {
+  changeDocument,
+  closeDocument,
+  emptyDocumentState,
+  openDocument,
+} from "./document_state.ts";
 
 const startLanguageServer = (
   connection: Connection,
@@ -137,7 +142,7 @@ const startLanguageServer = (
     return docSettings;
   };
 
-  const documents = new TextDocuments(TextDocument);
+  let documents = emptyDocumentState();
   let workspaceIndex = createWorkspaceIndex();
   let workspaceIndexUpdate: Promise<void> = Promise.resolve();
   const workspaceIndexDebounceMs = 75;
@@ -324,19 +329,34 @@ const startLanguageServer = (
     return handleRename(document, params, workspaceIndex);
   });
 
-  documents.onDidChangeContent((event) => {
-    void queueWorkspaceIndexUpdate(event.document);
+  connection.onDidOpenTextDocument((params) => {
+    const transition = openDocument(documents, params);
+    documents = transition.state;
+    if (transition.accepted) {
+      void queueWorkspaceIndexUpdate(transition.value);
+    }
   });
 
-  documents.onDidClose((event) => {
-    clearPendingWorkspaceIndexUpdate(event.document.uri);
+  connection.onDidChangeTextDocument((params) => {
+    const transition = changeDocument(documents, params);
+    documents = transition.state;
+    if (transition.accepted) {
+      void queueWorkspaceIndexUpdate(transition.value.document);
+    }
+  });
+
+  connection.onDidCloseTextDocument((params) => {
+    const transition = closeDocument(documents, params);
+    documents = transition.state;
+    if (!transition.accepted) {
+      return;
+    }
+    clearPendingWorkspaceIndexUpdate(transition.value.uri);
     workspaceIndex = removeSemanticIndexEntry(
       workspaceIndex,
-      event.document.uri,
+      transition.value.uri,
     );
   });
-
-  documents.listen(connection);
 
   connection.listen();
 };

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,3 +1,8 @@
+import type { TextDocument } from "vscode-languageserver-textdocument";
 import type { FileContent, Filename } from "../handlers/compilation/includes";
 
 export type FileSystemReader = (filename: Filename) => Promise<FileContent>;
+
+export type TextDocumentProvider = {
+  get(uri: string): TextDocument | undefined;
+};


### PR DESCRIPTION
@WardBrian  This is a prerequisite for solving #152 . To keep the AST up-to-date, the language server needs to keep track of all documents and if they have changed.