### PR TITLE
Restore incremental parsing

### DIFF
--- a/src/__tests__/language/ast/workspace_index.test.ts
+++ b/src/__tests__/language/ast/workspace_index.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, mock } from "bun:test";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import type { Edit, Tree } from "web-tree-sitter";
+import type { DocumentChange } from "../../../server/document_state";
 import {
   createWorkspaceIndex,
   getSemanticIndexEntry,
@@ -9,8 +11,18 @@ import {
 
 describe("workspace index", () => {
   it("adds, caches, updates, and removes a semantic index entry", async () => {
-    const document = TextDocument.create("file:///a.stan", "stan", 1, "parameters { real alpha; }");
-    const editedDocument = TextDocument.create("file:///a.stan", "stan", 2, "parameters { real beta; }");
+    const document = TextDocument.create(
+      "file:///a.stan",
+      "stan",
+      1,
+      "parameters { real alpha; }",
+    );
+    const editedDocument = TextDocument.create(
+      "file:///a.stan",
+      "stan",
+      2,
+      "parameters { real beta; }",
+    );
     const tree = { id: "tree-v1" } as any;
     const editedTree = { id: "tree-v2" } as any;
     let parseCount = 0;
@@ -20,7 +32,12 @@ describe("workspace index", () => {
     });
 
     const emptyIndex = createWorkspaceIndex();
-    const withEntry = await upsertSemanticIndexEntry(emptyIndex, document, parseDocument);
+    const withEntry = await upsertSemanticIndexEntry(
+      emptyIndex,
+      document,
+      [],
+      parseDocument,
+    );
     const entry = getSemanticIndexEntry(withEntry, document);
 
     expect(entry).not.toBeNull();
@@ -29,14 +46,25 @@ describe("workspace index", () => {
     expect(entry?.text).toBe(document.getText());
     expect(entry?.tree).toBe(tree);
 
-    const cachedIndex = await upsertSemanticIndexEntry(withEntry, document, parseDocument);
+    const cachedIndex = await upsertSemanticIndexEntry(
+      withEntry,
+      document,
+      [],
+      parseDocument,
+    );
     const cachedEntry = getSemanticIndexEntry(cachedIndex, document);
 
     expect(parseDocument).toHaveBeenCalledTimes(1);
+    expect(parseDocument.mock.calls[0]).toEqual([document.getText()]);
     expect(cachedIndex).toBe(withEntry);
     expect(cachedEntry).toBe(entry);
 
-    const updatedIndex = await upsertSemanticIndexEntry(cachedIndex, editedDocument, parseDocument);
+    const updatedIndex = await upsertSemanticIndexEntry(
+      cachedIndex,
+      editedDocument,
+      [],
+      parseDocument,
+    );
     const updatedEntry = getSemanticIndexEntry(updatedIndex, editedDocument);
 
     expect(parseDocument).toHaveBeenCalledTimes(2);
@@ -50,5 +78,634 @@ describe("workspace index", () => {
     const removedIndex = removeSemanticIndexEntry(updatedIndex, document.uri);
 
     expect(getSemanticIndexEntry(removedIndex, editedDocument)).toBeNull();
+  });
+
+  it("applies ordered document changes to a copied tree before parsing", async () => {
+    const uri = "file:///model.stan";
+    const version1 = TextDocument.create(uri, "stan", 1, "α bom x");
+    const version2 = TextDocument.create(uri, "stan", 2, "α blackjacxk x");
+    const version3 = TextDocument.create(uri, "stan", 3, "α blackjacxk result");
+    const firstChange: DocumentChange = {
+      previousDocument: version1,
+      document: version2,
+      contentChanges: [
+        {
+          range: {
+            start: { line: 0, character: 2 },
+            end: { line: 0, character: 5 },
+          },
+          rangeLength: 3,
+          text: "blackjacxk",
+        },
+      ],
+    };
+    const secondChange: DocumentChange = {
+      previousDocument: version2,
+      document: version3,
+      contentChanges: [
+        {
+          range: {
+            start: { line: 0, character: 13 },
+            end: { line: 0, character: 14 },
+          },
+          rangeLength: 1,
+          text: "result",
+        },
+      ],
+    };
+    const edit = mock((_inputEdit: Edit) => undefined);
+    const copiedTree = { edit } as unknown as Tree;
+    const copy = mock(() => copiedTree);
+    const version1Tree = { copy } as unknown as Tree;
+    const version3Tree = { id: "tree-v3" } as unknown as Tree;
+    let parseCount = 0;
+    const parseDocument = mock(async (_text: string, _oldTree?: Tree) => {
+      parseCount += 1;
+      return parseCount === 1 ? version1Tree : version3Tree;
+    });
+    const index = await upsertSemanticIndexEntry(
+      createWorkspaceIndex(),
+      version1,
+      [],
+      parseDocument,
+    );
+    const updatedIndex = await upsertSemanticIndexEntry(
+      index,
+      version3,
+      [firstChange, secondChange],
+      parseDocument,
+    );
+
+    expect(copy).toHaveBeenCalledTimes(1);
+    expect(edit).toHaveBeenCalledTimes(2);
+    expect(
+      edit.mock.calls.map(([inputEdit]) => ({
+        startIndex: inputEdit.startIndex,
+        oldEndIndex: inputEdit.oldEndIndex,
+        newEndIndex: inputEdit.newEndIndex,
+        startPosition: inputEdit.startPosition,
+        oldEndPosition: inputEdit.oldEndPosition,
+        newEndPosition: inputEdit.newEndPosition,
+      })),
+    ).toEqual([
+      {
+        startIndex: 3,
+        oldEndIndex: 6,
+        newEndIndex: 13,
+        startPosition: { row: 0, column: 3 },
+        oldEndPosition: { row: 0, column: 6 },
+        newEndPosition: { row: 0, column: 13 },
+      },
+      {
+        startIndex: 14,
+        oldEndIndex: 15,
+        newEndIndex: 20,
+        startPosition: { row: 0, column: 14 },
+        oldEndPosition: { row: 0, column: 15 },
+        newEndPosition: { row: 0, column: 20 },
+      },
+    ]);
+    expect(parseDocument.mock.calls[1]).toEqual([
+      version3.getText(),
+      copiedTree,
+    ]);
+    expect(getSemanticIndexEntry(updatedIndex, version3)?.tree).toBe(
+      version3Tree,
+    );
+  });
+
+  it("converts multiple ranged changes against sequential intermediate text", async () => {
+    const uri = "file:///unicode.stan";
+    const version1 = TextDocument.create(
+      uri,
+      "stan",
+      1,
+      "α\nreal café;\nreal x;",
+    );
+    const version2 = TextDocument.create(
+      uri,
+      "stan",
+      2,
+      "α\nreal naïve;\nreal result;",
+    );
+    const changes: DocumentChange[] = [
+      {
+        previousDocument: version1,
+        document: version2,
+        contentChanges: [
+          {
+            range: {
+              start: { line: 1, character: 5 },
+              end: { line: 1, character: 9 },
+            },
+            rangeLength: 4,
+            text: "naïve",
+          },
+          {
+            range: {
+              start: { line: 2, character: 5 },
+              end: { line: 2, character: 6 },
+            },
+            rangeLength: 1,
+            text: "result",
+          },
+        ],
+      },
+    ];
+    const edit = mock((_inputEdit: Edit) => undefined);
+    const copiedTree = { edit } as unknown as Tree;
+    const copy = mock(() => copiedTree);
+    const version1Tree = { copy } as unknown as Tree;
+    const version2Tree = { id: "tree-v2" } as unknown as Tree;
+    let parseCount = 0;
+    const parseDocument = mock(async (_text: string, _oldTree?: Tree) => {
+      parseCount += 1;
+      return parseCount === 1 ? version1Tree : version2Tree;
+    });
+
+    const index = await upsertSemanticIndexEntry(
+      createWorkspaceIndex(),
+      version1,
+      [],
+      parseDocument,
+    );
+    await upsertSemanticIndexEntry(index, version2, changes, parseDocument);
+
+    // Tree-sitter positions use UTF-8 bytes. The leading `α` occupies two
+    // bytes, so absolute byte indices differ from LSP UTF-16 characters.
+    expect(
+      edit.mock.calls.map(([inputEdit]) => ({
+        startIndex: inputEdit.startIndex,
+        oldEndIndex: inputEdit.oldEndIndex,
+        newEndIndex: inputEdit.newEndIndex,
+        startPosition: inputEdit.startPosition,
+        oldEndPosition: inputEdit.oldEndPosition,
+        newEndPosition: inputEdit.newEndPosition,
+      })),
+    ).toEqual([
+      // First edit, row 1:
+      //   before:
+      //     real café;
+      //          ^---^  columns 5..10, indices 8..13
+      //   after:
+      //     real naïve;
+      //          ^----^ columns 5..11, indices 8..14
+      {
+        startIndex: 8,
+        oldEndIndex: 13,
+        newEndIndex: 14,
+        startPosition: { row: 1, column: 5 },
+        oldEndPosition: { row: 1, column: 10 },
+        newEndPosition: { row: 1, column: 11 },
+      },
+      // Second edit is calculated against text after first edit, row 2:
+      //   before:
+      //     real x;
+      //          ^^     columns 5..6, indices 21..22
+      //   after:
+      //     real result;
+      //          ^-----^ columns 5..11, indices 21..27
+      {
+        startIndex: 21,
+        oldEndIndex: 22,
+        newEndIndex: 27,
+        startPosition: { row: 2, column: 5 },
+        oldEndPosition: { row: 2, column: 6 },
+        newEndPosition: { row: 2, column: 11 },
+      },
+    ]);
+    expect(parseDocument.mock.calls[1]).toEqual([
+      version2.getText(),
+      copiedTree,
+    ]);
+  });
+
+  describe("fresh parsing fallbacks", () => {
+    const fallbackCases: Array<{
+      name: string;
+      changes: (
+        previousDocument: TextDocument,
+        document: TextDocument,
+      ) => readonly DocumentChange[];
+    }> = [
+      {
+        name: "missing change metadata",
+        changes: () => [],
+      },
+      {
+        name: "a full-document replacement",
+        changes: (previousDocument, document) => [
+          {
+            previousDocument,
+            document,
+            contentChanges: [{ text: document.getText() }],
+          },
+        ],
+      },
+      {
+        name: "a stale starting version",
+        changes: (_previousDocument, document) => [
+          {
+            previousDocument: TextDocument.create(
+              document.uri,
+              "stan",
+              0,
+              "parameters { real alpha; }",
+            ),
+            document,
+            contentChanges: [
+              {
+                range: {
+                  start: { line: 0, character: 18 },
+                  end: { line: 0, character: 23 },
+                },
+                text: "beta",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "a non-contiguous revision chain",
+        changes: (previousDocument, document) => {
+          const version2 = TextDocument.create(
+            document.uri,
+            "stan",
+            2,
+            "parameters { real gamma; }",
+          );
+          const version4 = TextDocument.create(
+            document.uri,
+            "stan",
+            4,
+            document.getText(),
+          );
+          return [
+            {
+              previousDocument,
+              document: version2,
+              contentChanges: [
+                {
+                  range: {
+                    start: { line: 0, character: 18 },
+                    end: { line: 0, character: 23 },
+                  },
+                  text: "gamma",
+                },
+              ],
+            },
+            {
+              previousDocument: version4,
+              document,
+              contentChanges: [
+                {
+                  range: {
+                    start: { line: 0, character: 18 },
+                    end: { line: 0, character: 23 },
+                  },
+                  text: "beta",
+                },
+              ],
+            },
+          ];
+        },
+      },
+      {
+        name: "mismatched previous text",
+        changes: (_previousDocument, document) => [
+          {
+            previousDocument: TextDocument.create(
+              document.uri,
+              "stan",
+              1,
+              "parameters { real other; }",
+            ),
+            document,
+            contentChanges: [
+              {
+                range: {
+                  start: { line: 0, character: 18 },
+                  end: { line: 0, character: 23 },
+                },
+                text: "beta",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "an unsafe range",
+        changes: (previousDocument, document) => [
+          {
+            previousDocument,
+            document,
+            contentChanges: [
+              {
+                range: {
+                  start: { line: 0, character: 100 },
+                  end: { line: 0, character: 105 },
+                },
+                rangeLength: 5,
+                text: "beta",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "a mismatched range length",
+        changes: (previousDocument, document) => [
+          {
+            previousDocument,
+            document,
+            contentChanges: [
+              {
+                range: {
+                  start: { line: 0, character: 18 },
+                  end: { line: 0, character: 23 },
+                },
+                rangeLength: 4,
+                text: "beta",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "changes that do not produce the batch document text",
+        changes: (previousDocument, document) => [
+          {
+            previousDocument,
+            document,
+            contentChanges: [
+              {
+                range: {
+                  start: { line: 0, character: 18 },
+                  end: { line: 0, character: 23 },
+                },
+                rangeLength: 5,
+                text: "gamma",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "a revision chain that does not reach the requested version",
+        changes: (previousDocument, document) => [
+          {
+            previousDocument,
+            document: TextDocument.create(
+              document.uri,
+              document.languageId,
+              2,
+              document.getText(),
+            ),
+            contentChanges: [
+              {
+                range: {
+                  start: { line: 0, character: 18 },
+                  end: { line: 0, character: 23 },
+                },
+                rangeLength: 5,
+                text: "beta",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    for (const fallbackCase of fallbackCases) {
+      it(`fresh-parses without mutating the cached tree for ${fallbackCase.name}`, async () => {
+        const uri = "file:///fallback.stan";
+        const version1 = TextDocument.create(
+          uri,
+          "stan",
+          1,
+          "parameters { real alpha; }",
+        );
+        const version3 = TextDocument.create(
+          uri,
+          "stan",
+          3,
+          "parameters { real beta; }",
+        );
+        const cachedEdit = mock((_inputEdit: Edit) => undefined);
+        const copiedEdit = mock((_inputEdit: Edit) => undefined);
+        const copiedTree = { edit: copiedEdit } as unknown as Tree;
+        const cachedTree = {
+          copy: mock(() => copiedTree),
+          edit: cachedEdit,
+        } as unknown as Tree;
+        const freshTree = { id: "fresh-tree" } as unknown as Tree;
+        let parseCount = 0;
+        const parseDocument = mock(async (_text: string, _oldTree?: Tree) => {
+          parseCount += 1;
+          return parseCount === 1 ? cachedTree : freshTree;
+        });
+        const index = await upsertSemanticIndexEntry(
+          createWorkspaceIndex(),
+          version1,
+          [],
+          parseDocument,
+        );
+
+        const updatedIndex = await upsertSemanticIndexEntry(
+          index,
+          version3,
+          fallbackCase.changes(version1, version3),
+          parseDocument,
+        );
+
+        expect(cachedEdit).not.toHaveBeenCalled();
+        expect(parseDocument.mock.calls[1]).toEqual([version3.getText()]);
+        expect(getSemanticIndexEntry(updatedIndex, version3)?.tree).toBe(
+          freshTree,
+        );
+      });
+    }
+
+    it("fresh-parses when a change range splits a UTF-16 surrogate pair", async () => {
+      const uri = "file:///surrogate-fallback.stan";
+      const version1 = TextDocument.create(uri, "stan", 1, "real 😀alpha;");
+      const version2 = TextDocument.create(uri, "stan", 2, "real beta;");
+      const changes: DocumentChange[] = [
+        {
+          previousDocument: version1,
+          document: version2,
+          contentChanges: [
+            {
+              range: {
+                start: { line: 0, character: 6 },
+                end: { line: 0, character: 7 },
+              },
+              rangeLength: 1,
+              text: "beta",
+            },
+          ],
+        },
+      ];
+      const cachedEdit = mock((_inputEdit: Edit) => undefined);
+      const cachedTree = {
+        copy: mock(() => ({ edit: mock(() => undefined) }) as unknown as Tree),
+        edit: cachedEdit,
+      } as unknown as Tree;
+      const freshTree = { id: "fresh-tree" } as unknown as Tree;
+      let parseCount = 0;
+      const parseDocument = mock(async (_text: string, _oldTree?: Tree) => {
+        parseCount += 1;
+        return parseCount === 1 ? cachedTree : freshTree;
+      });
+      const index = await upsertSemanticIndexEntry(
+        createWorkspaceIndex(),
+        version1,
+        [],
+        parseDocument,
+      );
+
+      const updatedIndex = await upsertSemanticIndexEntry(
+        index,
+        version2,
+        changes,
+        parseDocument,
+      );
+
+      expect(cachedTree.copy).not.toHaveBeenCalled();
+      expect(cachedEdit).not.toHaveBeenCalled();
+      expect(parseDocument.mock.calls[1]).toEqual([version2.getText()]);
+      expect(getSemanticIndexEntry(updatedIndex, version2)?.tree).toBe(
+        freshTree,
+      );
+    });
+
+    describe("tree preparation failures", () => {
+      const treePreparationFailureCases = [
+        {
+          name: "copying the cached tree throws",
+          createCachedTree: () =>
+            ({
+              copy: mock(() => {
+                throw new Error("copy failed");
+              }),
+            }) as unknown as Tree,
+        },
+        {
+          name: "editing the copied tree throws",
+          createCachedTree: () =>
+            ({
+              copy: mock(
+                () =>
+                  ({
+                    edit: mock(() => {
+                      throw new Error("edit failed");
+                    }),
+                  }) as unknown as Tree,
+              ),
+            }) as unknown as Tree,
+        },
+      ];
+
+      for (const failureCase of treePreparationFailureCases) {
+        it(`fresh-parses when ${failureCase.name}`, async () => {
+          const uri = "file:///tree-preparation-fallback.stan";
+          const version1 = TextDocument.create(uri, "stan", 1, "real alpha;");
+          const version2 = TextDocument.create(uri, "stan", 2, "real beta;");
+          const changes: DocumentChange[] = [
+            {
+              previousDocument: version1,
+              document: version2,
+              contentChanges: [
+                {
+                  range: {
+                    start: { line: 0, character: 5 },
+                    end: { line: 0, character: 10 },
+                  },
+                  rangeLength: 5,
+                  text: "beta",
+                },
+              ],
+            },
+          ];
+          const cachedTree = failureCase.createCachedTree();
+          const freshTree = { id: "fresh-tree" } as unknown as Tree;
+          let parseCount = 0;
+          const parseDocument = mock(async (_text: string, _oldTree?: Tree) => {
+            parseCount += 1;
+            return parseCount === 1 ? cachedTree : freshTree;
+          });
+          const index = await upsertSemanticIndexEntry(
+            createWorkspaceIndex(),
+            version1,
+            [],
+            parseDocument,
+          );
+
+          const updatedIndex = await upsertSemanticIndexEntry(
+            index,
+            version2,
+            changes,
+            parseDocument,
+          );
+
+          expect(parseDocument.mock.calls[1]).toEqual([version2.getText()]);
+          expect(getSemanticIndexEntry(index, version1)?.tree).toBe(cachedTree);
+          expect(getSemanticIndexEntry(updatedIndex, version2)?.tree).toBe(
+            freshTree,
+          );
+        });
+      }
+    });
+  });
+
+  it("does not mutate the cached tree when incremental parsing fails", async () => {
+    const uri = "file:///parse-failure.stan";
+    const version1 = TextDocument.create(uri, "stan", 1, "real alpha;");
+    const version2 = TextDocument.create(uri, "stan", 2, "real beta;");
+    const changes: DocumentChange[] = [
+      {
+        previousDocument: version1,
+        document: version2,
+        contentChanges: [
+          {
+            range: {
+              start: { line: 0, character: 5 },
+              end: { line: 0, character: 10 },
+            },
+            rangeLength: 5,
+            text: "beta",
+          },
+        ],
+      },
+    ];
+    const cachedEdit = mock((_inputEdit: Edit) => undefined);
+    const copiedEdit = mock((_inputEdit: Edit) => undefined);
+    const copiedTree = { edit: copiedEdit } as unknown as Tree;
+    const cachedTree = {
+      copy: mock(() => copiedTree),
+      edit: cachedEdit,
+    } as unknown as Tree;
+    let parseCount = 0;
+    const parseDocument = mock(async (_text: string, _oldTree?: Tree) => {
+      parseCount += 1;
+      if (parseCount === 1) {
+        return cachedTree;
+      }
+      throw new Error("parse failed");
+    });
+    const index = await upsertSemanticIndexEntry(
+      createWorkspaceIndex(),
+      version1,
+      [],
+      parseDocument,
+    );
+
+    await expect(
+      upsertSemanticIndexEntry(index, version2, changes, parseDocument),
+    ).rejects.toThrow("parse failed");
+
+    expect(cachedEdit).not.toHaveBeenCalled();
+    expect(copiedEdit).toHaveBeenCalledTimes(1);
+    expect(getSemanticIndexEntry(index, version1)?.tree).toBe(cachedTree);
   });
 });

--- a/src/__tests__/server/workspace_state.test.ts
+++ b/src/__tests__/server/workspace_state.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, mock } from "bun:test";
+import type {
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenTextDocumentParams,
+} from "vscode-languageserver/node";
+import { getSemanticIndexEntry } from "../../language/ast/workspace_index";
+import {
+  changeWorkspaceDocument,
+  closeWorkspaceDocument,
+  createServerWorkspaceState,
+  forceWorkspaceIndexUpdate,
+  openWorkspaceDocument,
+  type WorkspaceIndexUpdateOptions,
+} from "../../server/workspace_state";
+
+const uri = "file:///workspace/model.stan";
+
+const options = (): WorkspaceIndexUpdateOptions => ({
+  debounceMs: 60_000,
+  reportError: mock((_uri: string, _error: unknown) => undefined),
+});
+
+const openParams = (
+  text = "parameters { real a; }",
+  version = 1,
+): DidOpenTextDocumentParams => ({
+  textDocument: {
+    uri,
+    languageId: "stan",
+    version,
+    text,
+  },
+});
+
+const changeParams = (
+  version: number,
+  start: number,
+  end: number,
+  text: string,
+): DidChangeTextDocumentParams => ({
+  textDocument: { uri, version },
+  contentChanges: [{
+    range: {
+      start: { line: 0, character: start },
+      end: { line: 0, character: end },
+    },
+    rangeLength: end - start,
+    text,
+  }],
+});
+
+const closeParams = (): DidCloseTextDocumentParams => ({
+  textDocument: { uri },
+});
+
+describe("server workspace state", () => {
+  it("owns document and workspace-index state", async () => {
+    const state = createServerWorkspaceState();
+    const updateOptions = options();
+
+    openWorkspaceDocument(state, openParams(), updateOptions);
+    const openedDocument = state.documents.get(uri);
+    if (!openedDocument) {
+      throw new Error("Expected document to be open");
+    }
+
+    expect(openedDocument.getText()).toBe("parameters { real a; }");
+    expect(state.indexing.pendingUpdates.get(uri)?.version).toBe(1);
+
+    await forceWorkspaceIndexUpdate(state, openedDocument, updateOptions);
+
+    expect(
+      getSemanticIndexEntry(state.indexing.index, openedDocument),
+    ).not.toBeNull();
+    expect(state.indexing.pendingUpdates.has(uri)).toBeFalse();
+
+    closeWorkspaceDocument(state, closeParams());
+
+    expect(state.documents.has(uri)).toBeFalse();
+    expect(state.indexing.index.entries.has(uri)).toBeFalse();
+    expect(state.indexing.pendingUpdates.has(uri)).toBeFalse();
+    expect(state.indexing.changeHistory.has(uri)).toBeFalse();
+  });
+
+  it("preserves ordered changes until latest document is indexed", async () => {
+    const state = createServerWorkspaceState();
+    const updateOptions = options();
+
+    openWorkspaceDocument(state, openParams(), updateOptions);
+    const openedDocument = state.documents.get(uri);
+    if (!openedDocument) {
+      throw new Error("Expected document to be open");
+    }
+    await forceWorkspaceIndexUpdate(state, openedDocument, updateOptions);
+
+    changeWorkspaceDocument(
+      state,
+      changeParams(2, 18, 19, "alpha"),
+      updateOptions,
+    );
+    const firstChange = state.indexing.changeHistory.get(uri)?.[0];
+    const pendingUpdate = state.indexing.pendingUpdates.get(uri);
+
+    changeWorkspaceDocument(
+      state,
+      changeParams(3, 18, 23, "beta"),
+      updateOptions,
+    );
+    const secondChange = state.indexing.changeHistory.get(uri)?.[1];
+    const latestDocument = state.documents.get(uri);
+    if (!firstChange || !secondChange || !latestDocument) {
+      throw new Error("Expected both document changes to be retained");
+    }
+
+    expect(state.indexing.pendingUpdates.get(uri)).toBe(pendingUpdate);
+    expect(state.indexing.pendingUpdates.get(uri)?.version).toBe(3);
+    expect(state.indexing.changeHistory.get(uri)).toEqual([
+      firstChange,
+      secondChange,
+    ]);
+
+    await forceWorkspaceIndexUpdate(
+      state,
+      latestDocument,
+      updateOptions,
+    );
+
+    expect(
+      getSemanticIndexEntry(state.indexing.index, latestDocument),
+    ).not.toBeNull();
+    expect(state.indexing.changeHistory.has(uri)).toBeFalse();
+    expect(state.indexing.pendingUpdates.has(uri)).toBeFalse();
+  });
+});

--- a/src/language/ast/workspace_index.ts
+++ b/src/language/ast/workspace_index.ts
@@ -1,5 +1,6 @@
-import type { TextDocument } from "vscode-languageserver-textdocument";
-import type { Tree } from "web-tree-sitter";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { Edit, type Point, type Tree } from "web-tree-sitter";
+import type { DocumentChange } from "../../server/document_state";
 import type {
   SemanticIndexEntry,
   WorkspaceIndex,
@@ -7,6 +8,198 @@ import type {
 import { buildSemanticIndex } from "./semantic_index";
 
 export type ParseDocument = (text: string, oldTree?: Tree) => Promise<Tree>;
+
+type EditProperties = ConstructorParameters<typeof Edit>[0];
+
+const textEncoder = new TextEncoder();
+
+const byteLength = (text: string): number => textEncoder.encode(text).byteLength;
+
+const isCodePointBoundary = (text: string, offset: number): boolean => {
+  if (offset <= 0 || offset >= text.length) {
+    return true;
+  }
+
+  const previous = text.charCodeAt(offset - 1);
+  const current = text.charCodeAt(offset);
+  const splitsSurrogatePair = previous >= 0xd800 && previous <= 0xdbff
+    && current >= 0xdc00 && current <= 0xdfff;
+  return !splitsSurrogatePair;
+};
+
+const exactOffsetAt = (
+  document: TextDocument,
+  position: { line: number; character: number },
+): number | null => {
+  const offset = document.offsetAt(position);
+  const actualPosition = document.positionAt(offset);
+  if (
+    actualPosition.line !== position.line
+    || actualPosition.character !== position.character
+    || !isCodePointBoundary(document.getText(), offset)
+  ) {
+    return null;
+  }
+  return offset;
+};
+
+const treeSitterPoint = (
+  document: TextDocument,
+  position: { line: number; character: number },
+  offset: number,
+): Point | null => {
+  const lineStartOffset = exactOffsetAt(document, {
+    line: position.line,
+    character: 0,
+  });
+  if (lineStartOffset === null) {
+    return null;
+  }
+
+  return {
+    row: position.line,
+    column: byteLength(document.getText().slice(lineStartOffset, offset)),
+  };
+};
+
+const pointAfterInsertedText = (start: Point, text: string): Point => {
+  let row = start.row;
+  let lastLineStart = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] === "\n") {
+      row += 1;
+      lastLineStart = index + 1;
+    }
+  }
+
+  return {
+    row,
+    column: row === start.row
+      ? start.column + byteLength(text)
+      : byteLength(text.slice(lastLineStart)),
+  };
+};
+
+const buildIncrementalEdits = (
+  previousEntry: SemanticIndexEntry,
+  document: TextDocument,
+  changes: readonly DocumentChange[],
+): EditProperties[] | null => {
+  if (changes.length === 0) {
+    return null;
+  }
+
+  let version = previousEntry.version;
+  let text = previousEntry.text;
+  const edits: EditProperties[] = [];
+
+  for (const batch of changes) {
+    const previousDocument = batch.previousDocument;
+    if (
+      previousDocument.uri !== document.uri
+      || batch.document.uri !== document.uri
+      || previousDocument.version !== version
+      || batch.document.version <= previousDocument.version
+      || previousDocument.getText() !== text
+      || batch.contentChanges.length === 0
+    ) {
+      return null;
+    }
+
+    let workingDocument = previousDocument;
+    for (const contentChange of batch.contentChanges) {
+      if (!("range" in contentChange)) {
+        return null;
+      }
+
+      const startOffset = exactOffsetAt(workingDocument, contentChange.range.start);
+      const endOffset = exactOffsetAt(workingDocument, contentChange.range.end);
+      if (
+        startOffset === null
+        || endOffset === null
+        || endOffset < startOffset
+        || (
+          contentChange.rangeLength !== undefined
+          && contentChange.rangeLength !== endOffset - startOffset
+        )
+      ) {
+        return null;
+      }
+
+      const startPosition = treeSitterPoint(
+        workingDocument,
+        contentChange.range.start,
+        startOffset,
+      );
+      const oldEndPosition = treeSitterPoint(
+        workingDocument,
+        contentChange.range.end,
+        endOffset,
+      );
+      if (startPosition === null || oldEndPosition === null) {
+        return null;
+      }
+
+      const workingText = workingDocument.getText();
+      const startIndex = byteLength(workingText.slice(0, startOffset));
+      const oldEndIndex = byteLength(workingText.slice(0, endOffset));
+      const insertedByteLength = byteLength(contentChange.text);
+      edits.push({
+        startIndex,
+        oldEndIndex,
+        newEndIndex: startIndex + insertedByteLength,
+        startPosition,
+        oldEndPosition,
+        newEndPosition: pointAfterInsertedText(startPosition, contentChange.text),
+      });
+
+      text = workingText.slice(0, startOffset)
+        + contentChange.text
+        + workingText.slice(endOffset);
+      workingDocument = TextDocument.create(
+        previousDocument.uri,
+        previousDocument.languageId,
+        previousDocument.version,
+        text,
+      );
+    }
+
+    if (text !== batch.document.getText()) {
+      return null;
+    }
+    version = batch.document.version;
+  }
+
+  if (version !== document.version || text !== document.getText()) {
+    return null;
+  }
+  return edits;
+};
+
+const prepareOldTree = (
+  previousEntry: SemanticIndexEntry | undefined,
+  document: TextDocument,
+  changes: readonly DocumentChange[],
+): Tree | null => {
+  if (!previousEntry) {
+    return null;
+  }
+
+  const edits = buildIncrementalEdits(previousEntry, document, changes);
+  if (edits === null) {
+    return null;
+  }
+
+  try {
+    const oldTree = previousEntry.tree.copy();
+    for (const edit of edits) {
+      oldTree.edit(new Edit(edit));
+    }
+    return oldTree;
+  } catch {
+    return null;
+  }
+};
 
 const parseWithTreeSitter: ParseDocument = async (text, oldTree) => {
   const { parse } = await import("./parser");
@@ -31,6 +224,7 @@ export const getSemanticIndexEntry = (
 export const upsertSemanticIndexEntry = async (
   index: WorkspaceIndex,
   document: TextDocument,
+  changes: readonly DocumentChange[] = [],
   parseDocument: ParseDocument = parseWithTreeSitter,
 ): Promise<WorkspaceIndex> => {
   const cachedEntry = getSemanticIndexEntry(index, document);
@@ -39,7 +233,14 @@ export const upsertSemanticIndexEntry = async (
   }
 
   const text = document.getText();
-  const tree = await parseDocument(text);
+  const oldTree = prepareOldTree(
+    index.entries.get(document.uri),
+    document,
+    changes,
+  );
+  const tree = oldTree === null
+    ? await parseDocument(text)
+    : await parseDocument(text, oldTree);
   const entry: SemanticIndexEntry = {
     uri: document.uri,
     version: document.version,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,11 +18,6 @@ import {
   handlePrepareRename,
   handleRename,
 } from "../handlers/index.ts";
-import {
-  createWorkspaceIndex,
-  removeSemanticIndexEntry,
-  upsertSemanticIndexEntry,
-} from "../language/ast/workspace_index.ts";
 import { type FileSystemReader } from "../types/common.ts";
 import {
   defaultSettings,
@@ -30,11 +25,13 @@ import {
 } from "../handlers/compilation/compilation.ts";
 import { SERVER_ID } from "../constants/index.ts";
 import {
-  changeDocument,
-  closeDocument,
-  emptyDocumentState,
-  openDocument,
-} from "./document_state.ts";
+  changeWorkspaceDocument,
+  closeWorkspaceDocument,
+  createServerWorkspaceState,
+  forceWorkspaceIndexUpdate,
+  openWorkspaceDocument,
+  type WorkspaceIndexUpdateOptions,
+} from "./workspace_state.ts";
 
 const startLanguageServer = (
   connection: Connection,
@@ -142,115 +139,22 @@ const startLanguageServer = (
     return docSettings;
   };
 
-  let documents = emptyDocumentState();
-  let workspaceIndex = createWorkspaceIndex();
-  let workspaceIndexUpdate: Promise<void> = Promise.resolve();
-  const workspaceIndexDebounceMs = 75;
-  type PendingWorkspaceIndexUpdate = {
-    timer?: ReturnType<typeof setTimeout>;
-    version: number;
-    promise: Promise<void>;
-    resolve: () => void;
+  const workspace = createServerWorkspaceState();
+  const workspaceIndexUpdateOptions: WorkspaceIndexUpdateOptions = {
+    debounceMs: 75,
+    reportError: (uri, error) => {
+      connection.console.error(
+        `Failed to update workspace index for ${uri}: ${String(error)}`,
+      );
+    },
   };
-  const pendingWorkspaceIndexUpdates = new Map<
-    string,
-    PendingWorkspaceIndexUpdate
-  >();
 
   const isStanDocument = (document: TextDocument) => {
     return document.languageId.startsWith("stan");
   };
 
-  const runWorkspaceIndexUpdate = (uri: string) => {
-    workspaceIndexUpdate = workspaceIndexUpdate
-      .catch(() => undefined)
-      .then(async () => {
-        const latestDocument = documents.get(uri);
-        if (!latestDocument || !isStanDocument(latestDocument)) {
-          return;
-        }
-
-        const nextWorkspaceIndex = await upsertSemanticIndexEntry(
-          workspaceIndex,
-          latestDocument,
-        );
-        const currentDocument = documents.get(uri);
-        if (currentDocument?.version === latestDocument.version) {
-          workspaceIndex = nextWorkspaceIndex;
-        }
-      })
-      .catch((error: unknown) => {
-        connection.console.error(
-          `Failed to update workspace index for ${uri}: ${String(error)}`,
-        );
-      });
-
-    return workspaceIndexUpdate;
-  };
-
-  const queueWorkspaceIndexUpdate = (document: TextDocument) => {
-    const uri = document.uri;
-    const existingUpdate = pendingWorkspaceIndexUpdates.get(uri);
-    if (existingUpdate?.timer) {
-      clearTimeout(existingUpdate.timer);
-    }
-
-    const createPendingUpdate = (): PendingWorkspaceIndexUpdate => {
-      let resolve!: () => void;
-      const promise = new Promise<void>((resolver) => {
-        resolve = resolver;
-      });
-      return {
-        version: document.version,
-        promise,
-        resolve,
-      };
-    };
-
-    const pendingUpdate = existingUpdate ?? createPendingUpdate();
-
-    pendingUpdate.version = document.version;
-    pendingUpdate.timer = setTimeout(() => {
-      if (pendingWorkspaceIndexUpdates.get(uri) !== pendingUpdate) {
-        return;
-      }
-      pendingWorkspaceIndexUpdates.delete(uri);
-      void runWorkspaceIndexUpdate(uri).finally(pendingUpdate.resolve);
-    }, workspaceIndexDebounceMs);
-    pendingWorkspaceIndexUpdates.set(uri, pendingUpdate);
-
-    return pendingUpdate.promise;
-  };
-
-  const clearPendingWorkspaceIndexUpdate = (uri: string) => {
-    const pendingUpdate = pendingWorkspaceIndexUpdates.get(uri);
-    if (!pendingUpdate) {
-      return;
-    }
-    if (pendingUpdate.timer) {
-      clearTimeout(pendingUpdate.timer);
-    }
-    pendingWorkspaceIndexUpdates.delete(uri);
-    pendingUpdate.resolve();
-  };
-
-  const forceWorkspaceIndexUpdate = async (document: TextDocument) => {
-    const pendingUpdate = pendingWorkspaceIndexUpdates.get(document.uri);
-    if (pendingUpdate) {
-      if (pendingUpdate.timer) {
-        clearTimeout(pendingUpdate.timer);
-      }
-      pendingWorkspaceIndexUpdates.delete(document.uri);
-      await runWorkspaceIndexUpdate(document.uri);
-      pendingUpdate.resolve();
-    } else {
-      await workspaceIndexUpdate;
-    }
-    workspaceIndex = await upsertSemanticIndexEntry(workspaceIndex, document);
-  };
-
   connection.onCompletion((params) => {
-    return handleCompletion(params, documents, hasSnippetSupport);
+    return handleCompletion(params, workspace.documents, hasSnippetSupport);
   });
 
   const getWorkspaceFolders = async () => {
@@ -267,7 +171,7 @@ const startLanguageServer = (
       kind: "full",
       items: await handleDiagnostics(
         params,
-        documents,
+        workspace.documents,
         folders,
         settings,
         connection.console,
@@ -281,7 +185,7 @@ const startLanguageServer = (
     const settings = await getDocumentSettings(params.textDocument.uri);
     const formattingResult = await handleFormatting(
       params,
-      documents,
+      workspace.documents,
       folders,
       settings,
       connection.console,
@@ -304,7 +208,7 @@ const startLanguageServer = (
   });
 
   connection.onHover((params) => {
-    const document = documents.get(params.textDocument.uri);
+    const document = workspace.documents.get(params.textDocument.uri);
     if (!document || !isStanDocument(document)) {
       return null;
     }
@@ -312,50 +216,45 @@ const startLanguageServer = (
   });
 
   connection.onPrepareRename(async (params) => {
-    const document = documents.get(params.textDocument.uri);
+    const document = workspace.documents.get(params.textDocument.uri);
     if (!document || !isStanDocument(document)) {
       return null;
     }
-    await forceWorkspaceIndexUpdate(document);
-    return handlePrepareRename(document, params, workspaceIndex);
+    await forceWorkspaceIndexUpdate(
+      workspace,
+      document,
+      workspaceIndexUpdateOptions,
+    );
+    return handlePrepareRename(
+      document,
+      params,
+      workspace.indexing.index,
+    );
   });
 
   connection.onRenameRequest(async (params) => {
-    const document = documents.get(params.textDocument.uri);
+    const document = workspace.documents.get(params.textDocument.uri);
     if (!document || !isStanDocument(document)) {
       return { documentChanges: [] };
     }
-    await forceWorkspaceIndexUpdate(document);
-    return handleRename(document, params, workspaceIndex);
+    await forceWorkspaceIndexUpdate(
+      workspace,
+      document,
+      workspaceIndexUpdateOptions,
+    );
+    return handleRename(document, params, workspace.indexing.index);
   });
 
   connection.onDidOpenTextDocument((params) => {
-    const transition = openDocument(documents, params);
-    documents = transition.state;
-    if (transition.accepted) {
-      void queueWorkspaceIndexUpdate(transition.value);
-    }
+    openWorkspaceDocument(workspace, params, workspaceIndexUpdateOptions);
   });
 
   connection.onDidChangeTextDocument((params) => {
-    const transition = changeDocument(documents, params);
-    documents = transition.state;
-    if (transition.accepted) {
-      void queueWorkspaceIndexUpdate(transition.value.document);
-    }
+    changeWorkspaceDocument(workspace, params, workspaceIndexUpdateOptions);
   });
 
   connection.onDidCloseTextDocument((params) => {
-    const transition = closeDocument(documents, params);
-    documents = transition.state;
-    if (!transition.accepted) {
-      return;
-    }
-    clearPendingWorkspaceIndexUpdate(transition.value.uri);
-    workspaceIndex = removeSemanticIndexEntry(
-      workspaceIndex,
-      transition.value.uri,
-    );
+    closeWorkspaceDocument(workspace, params);
   });
 
   connection.listen();

--- a/src/server/workspace_state.ts
+++ b/src/server/workspace_state.ts
@@ -1,0 +1,256 @@
+import type { TextDocument } from "vscode-languageserver-textdocument";
+import type {
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenTextDocumentParams,
+} from "vscode-languageserver/node";
+import {
+  createWorkspaceIndex,
+  removeSemanticIndexEntry,
+  upsertSemanticIndexEntry,
+} from "../language/ast/workspace_index.ts";
+import type { WorkspaceIndex } from "../language/ast/types.ts";
+import {
+  changeDocument,
+  closeDocument,
+  emptyDocumentState,
+  openDocument,
+  type DocumentChange,
+  type DocumentState,
+} from "./document_state.ts";
+
+export type PendingWorkspaceIndexUpdate = {
+  timer?: ReturnType<typeof setTimeout>;
+  version: number;
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+export type WorkspaceIndexingState = {
+  index: WorkspaceIndex;
+  update: Promise<void>;
+  pendingUpdates: Map<string, PendingWorkspaceIndexUpdate>;
+  changeHistory: Map<string, DocumentChange[]>;
+};
+
+export type ServerWorkspaceState = {
+  documents: DocumentState;
+  indexing: WorkspaceIndexingState;
+};
+
+export type WorkspaceIndexUpdateOptions = {
+  debounceMs: number;
+  reportError: (uri: string, error: unknown) => void;
+};
+
+export const createServerWorkspaceState = (): ServerWorkspaceState => ({
+  documents: emptyDocumentState(),
+  indexing: {
+    index: createWorkspaceIndex(),
+    update: Promise.resolve(),
+    pendingUpdates: new Map(),
+    changeHistory: new Map(),
+  },
+});
+
+const isStanDocument = (document: TextDocument): boolean => {
+  return document.languageId.startsWith("stan");
+};
+
+const consumeChanges = (
+  state: WorkspaceIndexingState,
+  uri: string,
+  changes: readonly DocumentChange[],
+): WorkspaceIndexingState => {
+  const currentHistory = state.changeHistory.get(uri);
+  if (
+    !currentHistory
+    || !changes.every((change, index) => currentHistory[index] === change)
+  ) {
+    return state;
+  }
+
+  const remainingChanges = currentHistory.slice(changes.length);
+  if (remainingChanges.length === 0) {
+    state.changeHistory.delete(uri);
+  } else {
+    state.changeHistory.set(uri, remainingChanges);
+  }
+  return state;
+};
+
+const runWorkspaceIndexUpdate = async (
+  state: ServerWorkspaceState,
+  uri: string,
+  options: WorkspaceIndexUpdateOptions,
+): Promise<ServerWorkspaceState> => {
+  state.indexing.update = state.indexing.update
+    .catch(() => undefined)
+    .then(async () => {
+      const latestDocument = state.documents.get(uri);
+      if (!latestDocument || !isStanDocument(latestDocument)) {
+        return;
+      }
+
+      const changes = [...(state.indexing.changeHistory.get(uri) ?? [])];
+      const nextIndex = await upsertSemanticIndexEntry(
+        state.indexing.index,
+        latestDocument,
+        changes,
+      );
+      if (state.documents.get(uri) === latestDocument) {
+        state.indexing.index = nextIndex;
+        consumeChanges(state.indexing, uri, changes);
+      }
+    })
+    .catch((error: unknown) => {
+      options.reportError(uri, error);
+    });
+
+  await state.indexing.update;
+  return state;
+};
+
+const queueWorkspaceIndexUpdate = (
+  state: ServerWorkspaceState,
+  document: TextDocument,
+  options: WorkspaceIndexUpdateOptions,
+  change?: DocumentChange,
+): ServerWorkspaceState => {
+  const uri = document.uri;
+  if (change) {
+    const changes = state.indexing.changeHistory.get(uri) ?? [];
+    state.indexing.changeHistory.set(uri, [...changes, change]);
+  }
+
+  const existingUpdate = state.indexing.pendingUpdates.get(uri);
+  if (existingUpdate?.timer) {
+    clearTimeout(existingUpdate.timer);
+  }
+
+  const createPendingUpdate = (): PendingWorkspaceIndexUpdate => {
+    let resolve!: () => void;
+    const promise = new Promise<void>((resolver) => {
+      resolve = resolver;
+    });
+    return {
+      version: document.version,
+      promise,
+      resolve,
+    };
+  };
+
+  const pendingUpdate = existingUpdate ?? createPendingUpdate();
+  pendingUpdate.version = document.version;
+  pendingUpdate.timer = setTimeout(() => {
+    if (state.indexing.pendingUpdates.get(uri) !== pendingUpdate) {
+      return;
+    }
+    state.indexing.pendingUpdates.delete(uri);
+    void runWorkspaceIndexUpdate(state, uri, options).finally(
+      pendingUpdate.resolve,
+    );
+  }, options.debounceMs);
+  state.indexing.pendingUpdates.set(uri, pendingUpdate);
+
+  return state;
+};
+
+const clearWorkspaceIndexUpdate = (
+  state: ServerWorkspaceState,
+  uri: string,
+): ServerWorkspaceState => {
+  const pendingUpdate = state.indexing.pendingUpdates.get(uri);
+  if (pendingUpdate?.timer) {
+    clearTimeout(pendingUpdate.timer);
+  }
+  if (pendingUpdate) {
+    state.indexing.pendingUpdates.delete(uri);
+    pendingUpdate.resolve();
+  }
+  state.indexing.changeHistory.delete(uri);
+  return state;
+};
+
+export const openWorkspaceDocument = (
+  state: ServerWorkspaceState,
+  params: DidOpenTextDocumentParams,
+  options: WorkspaceIndexUpdateOptions,
+): ServerWorkspaceState => {
+  const transition = openDocument(state.documents, params);
+  state.documents = transition.state;
+  if (transition.accepted) {
+    state.indexing.changeHistory.delete(transition.value.uri);
+    void queueWorkspaceIndexUpdate(
+      state,
+      transition.value,
+      options,
+    );
+  }
+  return state;
+};
+
+export const changeWorkspaceDocument = (
+  state: ServerWorkspaceState,
+  params: DidChangeTextDocumentParams,
+  options: WorkspaceIndexUpdateOptions,
+): ServerWorkspaceState => {
+  const transition = changeDocument(state.documents, params);
+  state.documents = transition.state;
+  if (transition.accepted) {
+    void queueWorkspaceIndexUpdate(
+      state,
+      transition.value.document,
+      options,
+      transition.value,
+    );
+  }
+  return state;
+};
+
+export const closeWorkspaceDocument = (
+  state: ServerWorkspaceState,
+  params: DidCloseTextDocumentParams,
+): ServerWorkspaceState => {
+  const transition = closeDocument(state.documents, params);
+  state.documents = transition.state;
+  if (transition.accepted) {
+    clearWorkspaceIndexUpdate(state, transition.value.uri);
+    state.indexing.index = removeSemanticIndexEntry(
+      state.indexing.index,
+      transition.value.uri,
+    );
+  }
+  return state;
+};
+
+export const forceWorkspaceIndexUpdate = async (
+  state: ServerWorkspaceState,
+  document: TextDocument,
+  options: WorkspaceIndexUpdateOptions,
+): Promise<ServerWorkspaceState> => {
+  const pendingUpdate = state.indexing.pendingUpdates.get(document.uri);
+  if (pendingUpdate) {
+    if (pendingUpdate.timer) {
+      clearTimeout(pendingUpdate.timer);
+    }
+    state.indexing.pendingUpdates.delete(document.uri);
+    await runWorkspaceIndexUpdate(state, document.uri, options);
+    pendingUpdate.resolve();
+  } else {
+    await state.indexing.update;
+  }
+
+  const changes = [...(
+    state.indexing.changeHistory.get(document.uri) ?? []
+  )];
+  state.indexing.index = await upsertSemanticIndexEntry(
+    state.indexing.index,
+    document,
+    changes,
+  );
+  if (state.documents.get(document.uri) === document) {
+    state.indexing.changeHistory.delete(document.uri);
+  }
+  return state;
+};


### PR DESCRIPTION
This PR build on #153 and actually restores incremental parsing, closing #154 . The workflow is to

- keep track of all changes that are made in the process of building/upserting the semantic index
- "replaying" all those changes using the `Tree.edit` method
- passing the edited tree to the treesitter parse