### PR TITLE
Introduce content provider

### DIFF
--- a/src/__tests__/e2e/server_lifecycle.test.ts
+++ b/src/__tests__/e2e/server_lifecycle.test.ts
@@ -1,5 +1,9 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "bun:test";
 import { RegistrationRequest, TextDocumentSyncKind, type InitializeResult } from "vscode-languageserver-protocol";
+import { URI } from "vscode-uri";
 import { LSPTestClient } from "./lsp-client";
 
 describe("Server Lifecycle", () => {
@@ -45,6 +49,35 @@ describe("Server Lifecycle", () => {
       await new Promise(resolve => setTimeout(resolve, 100));
 
       expect(client.serverMessages.map(message => message.params?.message)).toContain("Stan language server is initialized");
+    });
+
+    it("should discover Stan files during initialization", async () => {
+      const root = await mkdtemp(path.join(tmpdir(), "sls-discovery-"));
+      try {
+        await writeFile(path.join(root, "model.stan"), "model {}");
+        await writeFile(path.join(root, "functions.stanfunctions"), "");
+        await writeFile(path.join(root, "notes.txt"), "ignored");
+
+        client = new LSPTestClient();
+        await client.start();
+        await client.initialize(URI.file(root).toString());
+        await client.initialized();
+
+        const deadline = Date.now() + 2000;
+        while (
+          !client.serverMessages.some(
+            (message) => message.params?.message ===
+              "Discovered 2 Stan workspace files",
+          ) && Date.now() < deadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+
+        expect(client.serverMessages.map((message) => message.params?.message))
+          .toContain("Discovered 2 Stan workspace files");
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/__tests__/handlers/includes.test.ts
+++ b/src/__tests__/handlers/includes.test.ts
@@ -1,5 +1,4 @@
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { promises } from "fs";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { RemoteConsole } from "vscode-languageserver";
 import { TextDocuments, WorkspaceFolder } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -92,12 +91,9 @@ describe("Includes Handler", () => {
       expect(result).toEqual(expected);
     });
 
-    it("should prioritize workspace documents over filesystem", async () => {
+    it("should prioritize open documents over filesystem content", async () => {
       const includeFilename = "config.stan";
       const workspaceContent = "real workspace_function() { return 1; }";
-      const filesystemContent = "real filesystem_function() { return 2; }";
-
-      // Set up workspace document (should be chosen)
       const includeDocument = createMockDocument(
         "file:///workspace/config.stan",
         workspaceContent
@@ -106,59 +102,79 @@ describe("Includes Handler", () => {
         "file:///workspace/main.stan",
         '#include "config.stan"\nparameters { real x; } model { x ~ normal(0, 1); }'
       );
-
       const documentManager = createMockDocumentManager([includeDocument]);
-      const workspaceFolders = createMockWorkspaceFolders();
+      let reads = 0;
+      const reader = async (uri: string) => {
+        reads += 1;
+        return { uri, text: "disk", version: "disk-1", location: "disk" as const };
+      };
 
-      // Mock filesystem to return different content
-      const mockReadFile = spyOn(promises, "readFile").mockResolvedValue(filesystemContent);
+      const result = await handleIncludes(
+        mainDocument,
+        documentManager,
+        createMockWorkspaceFolders(),
+        [],
+        mockLogger,
+        reader,
+      );
 
-      try {
-        const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger);
-
-        // Should use workspace version, NOT filesystem version
-        expect(result).toEqual({
-          [includeFilename]: workspaceContent
-        });
-
-        // Filesystem should not be called since workspace succeeded
-        expect(mockReadFile).not.toHaveBeenCalled();
-      } finally {
-        mockReadFile.mockRestore();
-      }
+      expect(result).toEqual({ [includeFilename]: workspaceContent });
+      expect(reads).toBe(0);
     });
 
-    it("should fall back to filesystem when workspace document not found", async () => {
+    it("should fall back to filesystem when document is not open", async () => {
       const includeFilename = "config.stan";
       const filesystemContent = "real filesystem_function() { return 2; }";
-
       const mainDocument = createMockDocument(
         "file:///workspace/main.stan",
         '#include "config.stan"\nparameters { real x; } model { x ~ normal(0, 1); }'
       );
+      const reader = async (uri: string) => ({
+        uri,
+        text: filesystemContent,
+        version: "disk-1",
+        location: "disk" as const,
+      });
 
-      const reader = (filename: string) => promises.readFile(filename, "utf-8");
+      const result = await handleIncludes(
+        mainDocument,
+        createMockDocumentManager([]),
+        createMockWorkspaceFolders(),
+        [],
+        mockLogger,
+        reader,
+      );
 
-      // Empty document manager (no workspace documents)
-      const documentManager = createMockDocumentManager([]);
-      const workspaceFolders = createMockWorkspaceFolders();
+      expect(result).toEqual({ [includeFilename]: filesystemContent });
+    });
 
-      // Mock filesystem to return content
-      const mockReadFile = spyOn(promises, "readFile").mockResolvedValue(filesystemContent);
+    it("should continue after an unreadable include candidate", async () => {
+      const mainDocument = createMockDocument(
+        "file:///current/main.stan",
+        '#include "config.stan"',
+      );
+      const reader = async (uri: string) => {
+        if (uri.startsWith("file:///current/")) {
+          throw new Error("unreadable");
+        }
+        return {
+          uri,
+          text: "real workspace_function() { return 1; }",
+          version: "disk-1",
+          location: "disk" as const,
+        };
+      };
 
-      try {
-        const result = await handleIncludes(mainDocument, documentManager, workspaceFolders, [], mockLogger, reader);
+      const result = await handleIncludes(
+        mainDocument,
+        createMockDocumentManager([]),
+        createMockWorkspaceFolders(),
+        [],
+        mockLogger,
+        reader,
+      );
 
-        // Should use filesystem version since workspace had nothing
-        expect(result).toEqual({
-          [includeFilename]: filesystemContent
-        });
-
-        // Filesystem should have been called as fallback
-        expect(mockReadFile).toHaveBeenCalled();
-      } finally {
-        mockReadFile.mockRestore();
-      }
+      expect(result["config.stan"]).toContain("workspace_function");
     });
 
     it("should handle current directory includes", async () => {

--- a/src/__tests__/server/content_provider.test.ts
+++ b/src/__tests__/server/content_provider.test.ts
@@ -15,7 +15,6 @@ import {
   emptyDocumentState,
   openDocument,
 } from "../../server/document_state";
-import { workspaceFoldersFromInitialize } from "../../server/index";
 
 const createDeferred = <T>() => {
   let resolve!: (value: T) => void;
@@ -194,12 +193,5 @@ describe("content provider", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
-  });
-
-  it("uses rootUri fallback when initialization has no workspace folders", () => {
-    expect(workspaceFoldersFromInitialize({
-      workspaceFolders: null,
-      rootUri: "file:///workspace",
-    })).toEqual([{ uri: "file:///workspace", name: "file:///workspace" }]);
   });
 });

--- a/src/__tests__/server/content_provider.test.ts
+++ b/src/__tests__/server/content_provider.test.ts
@@ -1,0 +1,205 @@
+import { promises as fs } from "node:fs";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it, spyOn } from "bun:test";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { URI } from "vscode-uri";
+import {
+  listWorkspaceFiles,
+  readWorkspaceFile,
+} from "../../server/content_provider";
+import {
+  changeDocument,
+  closeDocument,
+  emptyDocumentState,
+  openDocument,
+} from "../../server/document_state";
+import { workspaceFoldersFromInitialize } from "../../server/index";
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+};
+
+describe("content provider", () => {
+  it("discovers supported files with stable ordering and duplicated-folder deduplication", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "sls-discovery-"));
+    try {
+      await mkdir(path.join(root, "nested"));
+      await writeFile(path.join(root, "z.stanfunctions"), "");
+      await writeFile(path.join(root, "nested", "a.stan"), "model {}");
+      await writeFile(path.join(root, "notes.txt"), "ignored");
+      const rootUri = URI.file(root).toString();
+
+      expect(listWorkspaceFiles([
+        { uri: rootUri, name: "first" },
+        { uri: rootUri, name: "duplicate" },
+      ])).resolves.toEqual([
+        URI.file(path.join(root, "nested", "a.stan")).toString(),
+        URI.file(path.join(root, "z.stanfunctions")).toString(),
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("tolerates empty workspaces and unreadable roots", async () => {
+    expect(listWorkspaceFiles([])).resolves.toEqual([]);
+    expect(listWorkspaceFiles([
+          { uri: URI.file("/missing/sls-workspace").toString(), name: "missing" },
+      ])).resolves.toEqual([]);
+  });
+
+  it("uses current open document instead of disk", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "sls-open-overlay-"));
+    try {
+      const filePath = path.join(root, "model.stan");
+      const uri = URI.file(filePath).toString();
+      await writeFile(filePath, "disk");
+      const document = TextDocument.create(uri, "stan", 7, "open");
+      const documentStore = new Map([[uri, document]])
+
+      expect(readWorkspaceFile(uri, documentStore))
+            .resolves.toEqual({
+                uri,
+                text: "open",
+                version: 7,
+                location: "documentStore",
+            });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rechecks document store after awaited disk reads", async () => {
+    const uri = URI.file("/pending/model.stan").toString();
+    const documentStore = new Map<string, TextDocument>();
+    const diskRead = createDeferred<Buffer>();
+    const mockedReadFile = spyOn(fs as any, "readFile").mockImplementation(
+      async () => await diskRead.promise,
+    );
+
+    try {
+      const read = readWorkspaceFile(uri, documentStore);
+      documentStore.set(
+        uri,
+        TextDocument.create(uri, "stan", 3, "opened while reading"),
+      );
+      diskRead.resolve(Buffer.from("stale disk"));
+
+      expect(read).resolves.toMatchObject({
+            text: "opened while reading",
+            version: 3,
+            location: "documentStore",
+        });
+    } finally {
+      mockedReadFile.mockRestore();
+    }
+  });
+
+  it("tracks document changes and falls back to disk after close", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "sls-overlay-"));
+    try {
+      const filePath = path.join(root, "model.stan");
+      const uri = URI.file(filePath).toString();
+      await writeFile(filePath, "disk");
+      let state = emptyDocumentState();
+
+      const opened = openDocument(state, {
+        textDocument: {
+          uri,
+          languageId: "stan",
+          version: 1,
+          text: "real foo;",
+        },
+      });
+      expect(opened.accepted).toBeTrue();
+      state = opened.state;
+
+      const ranged = changeDocument(state, {
+        textDocument: { uri, version: 2 },
+        contentChanges: [{
+          range: {
+            start: { line: 0, character: 5 },
+            end: { line: 0, character: 8 },
+          },
+          text: "bar",
+        }],
+      });
+      expect(ranged.accepted).toBeTrue();
+      state = ranged.state;
+      expect(readWorkspaceFile(uri, state)).resolves.toMatchObject({
+            text: "real bar;",
+            version: 2,
+        });
+
+      const replaced = changeDocument(state, {
+        textDocument: { uri, version: 3 },
+        contentChanges: [{ text: "real baz;" }],
+      });
+      expect(replaced.accepted).toBeTrue();
+      state = replaced.state;
+
+      const closed = closeDocument(state, { textDocument: { uri } });
+      expect(closed.accepted).toBeTrue();
+      expect(readWorkspaceFile(uri, closed.state)).resolves.toMatchObject({
+            text: "disk",
+            location: "disk",
+        });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reads explicitly referenced files excluded from discovery", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "sls-explicit-"));
+    try {
+      const filePath = path.join(root, "fragment.inc");
+      const uri = URI.file(filePath).toString();
+      await writeFile(filePath, "real x;");
+
+      expect(listWorkspaceFiles([
+            { uri: URI.file(root).toString(), name: "workspace" },
+        ])).resolves.toEqual([]);
+      expect(readWorkspaceFile(uri, new Map())).resolves.toMatchObject({
+            uri,
+            text: "real x;",
+            location: "disk",
+        });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("handles encoded and Unicode file URIs", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "sls-unicode-"));
+    try {
+      const nested = path.join(root, "space ü");
+      const filePath = path.join(nested, "model %.stan");
+      await mkdir(nested);
+      await writeFile(filePath, "parameters { real x; }");
+      const uri = URI.file(filePath).toString();
+
+      expect(listWorkspaceFiles([
+            { uri: URI.file(root).toString(), name: "workspace" },
+        ])).resolves.toEqual([uri]);
+      expect(readWorkspaceFile(uri, new Map())).resolves.toMatchObject({
+            text: "parameters { real x; }",
+            location: "disk",
+        });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses rootUri fallback when initialization has no workspace folders", () => {
+    expect(workspaceFoldersFromInitialize({
+      workspaceFolders: null,
+      rootUri: "file:///workspace",
+    })).toEqual([{ uri: "file:///workspace", name: "file:///workspace" }]);
+  });
+});

--- a/src/__tests__/server/initialization.test.ts
+++ b/src/__tests__/server/initialization.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { workspaceFoldersFromInitialize } from "../../server/initialization";
+
+describe("server initialization", () => {
+  it("uses rootUri when workspace folders are unavailable", () => {
+    expect(workspaceFoldersFromInitialize({
+      workspaceFolders: null,
+      rootUri: "file:///workspace",
+    })).toEqual([
+      {
+        uri: "file:///workspace",
+        name: "file:///workspace",
+      },
+    ]);
+  });
+});

--- a/src/handlers/compilation/compilation.ts
+++ b/src/handlers/compilation/compilation.ts
@@ -4,7 +4,10 @@ import {
   type RemoteConsole,
 } from "vscode-languageserver";
 import { handleIncludes } from "./includes";
-import type { FileSystemReader, TextDocumentProvider } from "../../types/common";
+import type {
+  TextDocumentProvider,
+  WorkspaceFileReader,
+} from "../../types/common";
 import { URI } from "vscode-uri";
 import { stanc, type StancReturn } from "stanc3";
 
@@ -29,7 +32,7 @@ export async function handleCompilation(
   settings: Settings,
   purpose: Purpose,
   logger: RemoteConsole,
-  reader?: FileSystemReader,
+  reader?: WorkspaceFileReader,
 ): Promise<StancReturn> {
   const filename = URI.parse(document.uri).fsPath;
   const code = document.getText();

--- a/src/handlers/compilation/includes.ts
+++ b/src/handlers/compilation/includes.ts
@@ -1,11 +1,13 @@
-import {
+import type {
+  RemoteConsole,
   WorkspaceFolder,
-  type RemoteConsole,
 } from "vscode-languageserver";
-import { join } from "path";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { URI, Utils } from "vscode-uri";
-import type { FileSystemReader, TextDocumentProvider } from "../../types";
+import type {
+  TextDocumentProvider,
+  WorkspaceFileReader,
+} from "../../types";
 
 export type Filename = string;
 export type FileContent = string;
@@ -13,11 +15,9 @@ export type FilePathError = { msg: string };
 
 export function getFilenames(fileContent: string): Filename[] {
   const includePattern = /#include\s*[<"]?([^>"\s]*)[>"]?/g;
-
-  const matches = Array.from(fileContent.matchAll(includePattern));
-  const results = matches.map((match) => match[1] || "");
-
-  return results;
+  return Array.from(fileContent.matchAll(includePattern)).map(
+    (match) => match[1] || "",
+  );
 }
 
 export function isFilePathError(value: unknown): value is FilePathError {
@@ -30,12 +30,11 @@ export async function handleIncludes(
   workspaceFolders: WorkspaceFolder[],
   includePaths: string[],
   logger: RemoteConsole,
-  reader?: FileSystemReader,
-  alreadyIncluded: Set<Filename> = new Set()
+  reader?: WorkspaceFileReader,
+  alreadyIncluded: Set<Filename> = new Set(),
 ): Promise<Record<Filename, FileContent>> {
   try {
     const includeFilenames = getFilenames(document.getText());
-
     if (includeFilenames.length === 0) {
       return {};
     }
@@ -52,36 +51,35 @@ export async function handleIncludes(
             workspaceFolders,
             includePaths,
             filename,
-            reader
+            reader,
           );
           return [filename, content];
         } catch (err) {
           return [filename, { msg: `${(err as Error).message}` }];
         }
-      })
+      }),
     );
 
     const validResults = allResults.filter(
-      ([_, content]) => !isFilePathError(content)
+      ([, content]) => !isFilePathError(content),
     ) as [Filename, TextDocument][];
 
     const currentlyIncluded = new Set(
-      validResults.map(([filename, _]) => filename)
+      validResults.map(([filename]) => filename),
     ).union(alreadyIncluded);
 
     const recursiveIncludes = await Promise.all(
-      validResults.map(
-        async ([_, content]) =>
-          await handleIncludes(
-            content,
-            documentManager,
-            workspaceFolders,
-            includePaths,
-            logger,
-            reader,
-            currentlyIncluded
-          )
-      )
+      validResults.map(([, content]) =>
+        handleIncludes(
+          content,
+          documentManager,
+          workspaceFolders,
+          includePaths,
+          logger,
+          reader,
+          currentlyIncluded,
+        ),
+      ),
     );
 
     const results = validResults
@@ -91,9 +89,24 @@ export async function handleIncludes(
     return Object.fromEntries(results);
   } catch (error) {
     logger.warn(`Resolving included files failed: ${error}`);
-    return Promise.resolve({});
+    return {};
   }
 }
+
+const candidateUris = (
+  documentUri: string,
+  workspaceFolders: readonly WorkspaceFolder[],
+  includePaths: readonly string[],
+  filename: Filename,
+): readonly string[] => {
+  const bases = [
+    Utils.dirname(URI.parse(documentUri)),
+    ...workspaceFolders.map(({ uri }) => URI.parse(uri)),
+    ...includePaths.map((includePath) => URI.file(includePath)),
+  ];
+
+  return [...new Set(bases.map((base) => Utils.joinPath(base, filename).toString()))];
+};
 
 const readIncludedFile = async (
   document: TextDocument,
@@ -101,82 +114,33 @@ const readIncludedFile = async (
   workspaceFolders: WorkspaceFolder[],
   includePaths: string[],
   filename: Filename,
-  reader?: FileSystemReader
+  reader?: WorkspaceFileReader,
 ): Promise<TextDocument | FilePathError> => {
-  const currentDir = Utils.dirname(URI.parse(document.uri));
-
-  let includedFileContent = await readIncludedFileFromWorkspace(
-    documentManager,
+  for (const uri of candidateUris(
+    document.uri,
     workspaceFolders,
+    includePaths,
     filename,
-    currentDir
-  );
+  )) {
+    const openDocument = documentManager.get(uri);
+    if (openDocument) {
+      return openDocument;
+    }
 
-  if (!isFilePathError(includedFileContent)) {
-    return Promise.resolve(includedFileContent);
-  }
-
-  if (reader) {
-    includedFileContent = await readIncludedFileFromFileSystem(
-      filename,
-      [currentDir.fsPath, ...includePaths],
-      reader
-    );
-  }
-
-  if (!isFilePathError(includedFileContent)) {
-    return Promise.resolve(includedFileContent);
-  }
-
-  return Promise.resolve({ msg: `File not found: ${filename}` });
-};
-
-const readIncludedFileFromWorkspace = (
-  documentManager: TextDocumentProvider,
-  workspaceFolders: WorkspaceFolder[],
-  filename: Filename,
-  currentDir: URI
-): Promise<TextDocument | FilePathError> => {
-  const searchFolders = [
-    { uri: currentDir.toString(), name: "stan file directory" },
-    ...workspaceFolders,
-  ];
-
-  const paths = searchFolders.map((folder) => folder.uri + "/" + filename);
-  const documents = paths.map((path) => {
-    const doc = documentManager.get(path);
-
-    return { path, doc };
-  });
-
-  const includedFile = documents
-    .filter(({ doc }) => doc !== undefined)
-    .map(({ doc }) => doc)[0];
-
-  if (!includedFile) {
-    return Promise.resolve({ msg: `File not found: ${filename}` });
-  }
-  return Promise.resolve(includedFile);
-};
-
-const readIncludedFileFromFileSystem = async (
-  filename: Filename,
-  dirs: string[],
-  fileSystemReader: FileSystemReader
-): Promise<TextDocument | FilePathError> => {
-  for (const currentDir of dirs) {
     try {
-      const localPath = join(currentDir, filename);
-      const content = await fileSystemReader(localPath);
-      return TextDocument.create(
-        URI.file(localPath).toString(),
-        "stan",
-        0,
-        content
-      );
-    } catch (_error) {
-      // ignored
+      const file = await reader?.(uri);
+      if (file) {
+        return TextDocument.create(
+          file.uri,
+          file.uri.endsWith(".stanfunctions") ? "stanfunctions" : "stan",
+          typeof file.version === "number" ? file.version : 0,
+          file.text,
+        );
+      }
+    } catch {
+      // Try remaining workspace/include-path candidates.
     }
   }
-  return Promise.resolve({ msg: `File not found: ${filename}` });
+
+  return { msg: `File not found: ${filename}` };
 };

--- a/src/handlers/diagnostics.ts
+++ b/src/handlers/diagnostics.ts
@@ -9,7 +9,7 @@ import { SERVER_ID } from "../constants";
 import {
     provideDiagnostics
 } from "../language/diagnostics/provider";
-import type { FileSystemReader, TextDocumentProvider } from "../types";
+import type { TextDocumentProvider, WorkspaceFileReader } from "../types";
 import { handleCompilation, type Settings } from "./compilation/compilation";
 
 export async function handleDiagnostics(
@@ -18,7 +18,7 @@ export async function handleDiagnostics(
   workspaceFolders: WorkspaceFolder[],
   settings: Settings,
   logger: RemoteConsole,
-  reader?: FileSystemReader
+  reader?: WorkspaceFileReader
 ): Promise<Diagnostic[]> {
   const document = documents.get(params.textDocument.uri);
   if (!document || !document.languageId.startsWith("stan")) {

--- a/src/handlers/formatting.ts
+++ b/src/handlers/formatting.ts
@@ -5,7 +5,7 @@ import type {
   WorkspaceFolder,
 } from "vscode-languageserver";
 import { handleCompilation, type Settings } from "./compilation/compilation";
-import type { FileSystemReader, TextDocumentProvider } from "../types";
+import type { TextDocumentProvider, WorkspaceFileReader } from "../types";
 
 export async function handleFormatting(
   params: DocumentFormattingParams,
@@ -13,7 +13,7 @@ export async function handleFormatting(
   workspaceFolders: WorkspaceFolder[],
   settings: Settings,
   logger: RemoteConsole,
-  reader?: FileSystemReader,
+  reader?: WorkspaceFileReader,
 ): Promise<TextEdit[] | { errors: string[] }> {
   const document = documents.get(params.textDocument.uri);
   if (!document || !document.languageId.startsWith("stan")) {

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -1,5 +1,3 @@
-import { promises } from "fs";
-
 import { createConnection, type Connection } from "vscode-languageserver/node";
 import startLanguageServer from "./index";
 
@@ -42,4 +40,4 @@ try {
   }
   process.exit(1);
 }
-startLanguageServer(connection, (f) => promises.readFile(f, "utf-8"));
+startLanguageServer(connection);

--- a/src/server/content_provider.ts
+++ b/src/server/content_provider.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { WorkspaceFolder } from "vscode-languageserver";
+import type { TextDocument } from "vscode-languageserver-textdocument";
+import { URI } from "vscode-uri";
+
+const supportedStanExtensions = [".stan", ".stanfunctions"] as const;
+
+export type FileUri = string;
+export type FileLocation = "documentStore" | "disk";
+export type FileVersion = number | string;
+
+export type WorkspaceFile = {
+  uri: FileUri;
+  text: string;
+  version: FileVersion;
+  location: FileLocation;
+};
+
+export type DocumentStoreReader = {
+  get(uri: FileUri): TextDocument | undefined;
+};
+
+const filePathToUri = (filePath: string): FileUri =>
+  URI.file(filePath).toString();
+
+const uriToFilePath = (uri: FileUri): string => URI.parse(uri).fsPath;
+
+const isSupportedStanUri = (uri: FileUri): boolean => {
+  try {
+    const uriPath = new URL(uri).pathname.toLowerCase();
+    return supportedStanExtensions.some((extension) =>
+      uriPath.endsWith(extension)
+    );
+  } catch {
+    return false;
+  }
+};
+
+const sortedDirectoryEntries = async (directoryPath: string) => {
+  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+  return entries.sort((left, right) => left.name.localeCompare(right.name));
+};
+
+const listFilesRecursive = async (
+  directoryPath: string,
+): Promise<FileUri[]> => {
+  const uris: FileUri[] = [];
+  const entries = await sortedDirectoryEntries(directoryPath);
+
+  for (const entry of entries) {
+    const entryPath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      try {
+        uris.push(...await listFilesRecursive(entryPath));
+      } catch {
+        // Unreadable child directory does not hide readable siblings.
+      }
+    } else if (entry.isFile()) {
+      uris.push(filePathToUri(entryPath));
+    }
+  }
+
+  return uris;
+};
+
+const listFolderFiles = async (
+  uri: FileUri,
+): Promise<readonly FileUri[]> => {
+  const filePath = uriToFilePath(uri);
+  const stats = await fs.stat(filePath);
+  if (stats.isFile()) {
+    return [filePathToUri(filePath)];
+  }
+  if (!stats.isDirectory()) {
+    return [];
+  }
+  return await listFilesRecursive(filePath);
+};
+
+export const listWorkspaceFiles = async (
+  workspaceFolders: readonly WorkspaceFolder[],
+): Promise<readonly FileUri[]> => {
+  const listings = await Promise.all(
+    workspaceFolders.map(async ({ uri }) => {
+      try {
+        return await listFolderFiles(uri);
+      } catch {
+        return [];
+      }
+    }),
+  );
+
+  return [...new Set(listings.flat().filter(isSupportedStanUri))].sort(
+    (left, right) => left.localeCompare(right),
+  );
+};
+
+const workspaceFileFromDocument = (document: TextDocument): WorkspaceFile => ({
+  uri: document.uri,
+  text: document.getText(),
+  version: document.version,
+  location: "documentStore",
+});
+
+const readOpenDocument = (
+  uri: FileUri,
+  documents: DocumentStoreReader,
+): WorkspaceFile | null => {
+  const document = documents.get(uri);
+  return document ? workspaceFileFromDocument(document) : null;
+};
+
+const readFromDisk = async (
+  uri: FileUri,
+): Promise<WorkspaceFile | null> => {
+  try {
+    const text = await fs.readFile(uriToFilePath(uri), "utf8");
+    return {
+      uri,
+      text,
+      version: createHash("sha256").update(text).digest("hex"),
+      location: "disk",
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const readWorkspaceFile = async (
+  uri: FileUri,
+  documents: DocumentStoreReader,
+): Promise<WorkspaceFile | null> => {
+  const openFile = readOpenDocument(uri, documents);
+  if (openFile) {
+    return openFile;
+  }
+
+  const diskFile = await readFromDisk(uri);
+
+  // Document may have opened while disk read was pending.
+  return readOpenDocument(uri, documents) ?? diskFile;
+};

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,6 +9,7 @@ import {
   type Connection,
   type InitializeParams,
   type InitializeResult,
+  type WorkspaceFolder,
 } from "vscode-languageserver/node";
 import {
   handleCompletion,
@@ -18,7 +19,10 @@ import {
   handlePrepareRename,
   handleRename,
 } from "../handlers/index.ts";
-import { type FileSystemReader } from "../types/common.ts";
+import {
+  listWorkspaceFiles,
+  readWorkspaceFile,
+} from "./content_provider.ts";
 import {
   defaultSettings,
   type Settings,
@@ -33,19 +37,40 @@ import {
   type WorkspaceIndexUpdateOptions,
 } from "./workspace_state.ts";
 
-const startLanguageServer = (
-  connection: Connection,
-  reader?: FileSystemReader,
-) => {
+export const workspaceFoldersFromInitialize = (
+  params: Pick<InitializeParams, "workspaceFolders" | "rootUri">,
+): WorkspaceFolder[] => {
+  if (params.workspaceFolders && params.workspaceFolders.length > 0) {
+    return [...params.workspaceFolders];
+  }
+  return params.rootUri
+    ? [{ uri: params.rootUri, name: params.rootUri }]
+    : [];
+};
+
+type ContentProvider = {
+  listWorkspaceFiles: typeof listWorkspaceFiles;
+  readWorkspaceFile: typeof readWorkspaceFile;
+};
+
+const contentProvider: ContentProvider = {
+  listWorkspaceFiles,
+  readWorkspaceFile,
+};
+
+const startLanguageServer = (connection: Connection) => {
   let hasConfigurationCapability: boolean = false;
   let hasWorkspaceFolderCapability: boolean = false;
   let hasDynamicConfigurationRequestCapability: boolean = false;
   let hasSnippetSupport: boolean = false;
+  let initializationWorkspaceFolders: WorkspaceFolder[] = [];
+  let discoveredWorkspaceFiles: readonly string[] = [];
 
   connection.onInitialize((params: InitializeParams): InitializeResult => {
     connection.console.info("Initializing Stan language server...");
 
     const capabilities = params.capabilities;
+    initializationWorkspaceFolders = workspaceFoldersFromInitialize(params);
 
     hasConfigurationCapability = Boolean(capabilities.workspace?.configuration);
     hasDynamicConfigurationRequestCapability = Boolean(
@@ -95,6 +120,12 @@ const startLanguageServer = (
       connection.console.info("Registered for didChangeConfiguration");
     }
     connection.console.info("Stan language server is initialized");
+    discoveredWorkspaceFiles = await contentProvider.listWorkspaceFiles(
+      initializationWorkspaceFolders,
+    );
+    connection.console.info(
+      `Discovered ${discoveredWorkspaceFiles.length} Stan workspace files`,
+    );
   });
 
   connection.onExit(() => {
@@ -139,7 +170,9 @@ const startLanguageServer = (
     return docSettings;
   };
 
-  const workspace = createServerWorkspaceState();
+  const workspaceState = createServerWorkspaceState();
+  const readFile = (uri: string) =>
+    contentProvider.readWorkspaceFile(uri, workspaceState.documents);
   const workspaceIndexUpdateOptions: WorkspaceIndexUpdateOptions = {
     debounceMs: 75,
     reportError: (uri, error) => {
@@ -154,14 +187,17 @@ const startLanguageServer = (
   };
 
   connection.onCompletion((params) => {
-    return handleCompletion(params, workspace.documents, hasSnippetSupport);
+    return handleCompletion(params, workspaceState.documents, hasSnippetSupport);
   });
 
-  const getWorkspaceFolders = async () => {
+  const getWorkspaceFolders = async (): Promise<WorkspaceFolder[]> => {
     if (hasWorkspaceFolderCapability) {
-      return (await connection.workspace.getWorkspaceFolders()) || [];
+      const currentFolders = await connection.workspace.getWorkspaceFolders();
+      if (currentFolders && currentFolders.length > 0) {
+        return currentFolders;
+      }
     }
-    return [];
+    return initializationWorkspaceFolders;
   };
 
   connection.onRequest(DocumentDiagnosticRequest.method, async (params) => {
@@ -171,11 +207,11 @@ const startLanguageServer = (
       kind: "full",
       items: await handleDiagnostics(
         params,
-        workspace.documents,
+        workspaceState.documents,
         folders,
         settings,
         connection.console,
-        reader,
+        readFile,
       ),
     };
   });
@@ -185,11 +221,11 @@ const startLanguageServer = (
     const settings = await getDocumentSettings(params.textDocument.uri);
     const formattingResult = await handleFormatting(
       params,
-      workspace.documents,
+      workspaceState.documents,
       folders,
       settings,
       connection.console,
-      reader,
+      readFile,
     );
     if (Array.isArray(formattingResult)) {
       return formattingResult;
@@ -208,7 +244,7 @@ const startLanguageServer = (
   });
 
   connection.onHover((params) => {
-    const document = workspace.documents.get(params.textDocument.uri);
+    const document = workspaceState.documents.get(params.textDocument.uri);
     if (!document || !isStanDocument(document)) {
       return null;
     }
@@ -216,45 +252,45 @@ const startLanguageServer = (
   });
 
   connection.onPrepareRename(async (params) => {
-    const document = workspace.documents.get(params.textDocument.uri);
+    const document = workspaceState.documents.get(params.textDocument.uri);
     if (!document || !isStanDocument(document)) {
       return null;
     }
     await forceWorkspaceIndexUpdate(
-      workspace,
+      workspaceState,
       document,
       workspaceIndexUpdateOptions,
     );
     return handlePrepareRename(
       document,
       params,
-      workspace.indexing.index,
+      workspaceState.indexing.index,
     );
   });
 
   connection.onRenameRequest(async (params) => {
-    const document = workspace.documents.get(params.textDocument.uri);
+    const document = workspaceState.documents.get(params.textDocument.uri);
     if (!document || !isStanDocument(document)) {
       return { documentChanges: [] };
     }
     await forceWorkspaceIndexUpdate(
-      workspace,
+      workspaceState,
       document,
       workspaceIndexUpdateOptions,
     );
-    return handleRename(document, params, workspace.indexing.index);
+    return handleRename(document, params, workspaceState.indexing.index);
   });
 
   connection.onDidOpenTextDocument((params) => {
-    openWorkspaceDocument(workspace, params, workspaceIndexUpdateOptions);
+    openWorkspaceDocument(workspaceState, params, workspaceIndexUpdateOptions);
   });
 
   connection.onDidChangeTextDocument((params) => {
-    changeWorkspaceDocument(workspace, params, workspaceIndexUpdateOptions);
+    changeWorkspaceDocument(workspaceState, params, workspaceIndexUpdateOptions);
   });
 
   connection.onDidCloseTextDocument((params) => {
-    closeWorkspaceDocument(workspace, params);
+    closeWorkspaceDocument(workspaceState, params);
   });
 
   connection.listen();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,6 +28,7 @@ import {
   type Settings,
 } from "../handlers/compilation/compilation.ts";
 import { SERVER_ID } from "../constants/index.ts";
+import type { ContentProvider } from "../types/common.ts";
 import {
   changeWorkspaceDocument,
   closeWorkspaceDocument,
@@ -46,11 +47,6 @@ export const workspaceFoldersFromInitialize = (
   return params.rootUri
     ? [{ uri: params.rootUri, name: params.rootUri }]
     : [];
-};
-
-type ContentProvider = {
-  listWorkspaceFiles: typeof listWorkspaceFiles;
-  readWorkspaceFile: typeof readWorkspaceFile;
 };
 
 const contentProvider: ContentProvider = {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -29,6 +29,7 @@ import {
 } from "../handlers/compilation/compilation.ts";
 import { SERVER_ID } from "../constants/index.ts";
 import type { ContentProvider } from "../types/common.ts";
+import { workspaceFoldersFromInitialize } from "./initialization.ts";
 import {
   changeWorkspaceDocument,
   closeWorkspaceDocument,
@@ -37,17 +38,6 @@ import {
   openWorkspaceDocument,
   type WorkspaceIndexUpdateOptions,
 } from "./workspace_state.ts";
-
-export const workspaceFoldersFromInitialize = (
-  params: Pick<InitializeParams, "workspaceFolders" | "rootUri">,
-): WorkspaceFolder[] => {
-  if (params.workspaceFolders && params.workspaceFolders.length > 0) {
-    return [...params.workspaceFolders];
-  }
-  return params.rootUri
-    ? [{ uri: params.rootUri, name: params.rootUri }]
-    : [];
-};
 
 const contentProvider: ContentProvider = {
   listWorkspaceFiles,

--- a/src/server/initialization.ts
+++ b/src/server/initialization.ts
@@ -1,0 +1,16 @@
+import type {
+  InitializeParams,
+  WorkspaceFolder,
+} from "vscode-languageserver/node";
+
+export const workspaceFoldersFromInitialize = (
+  params: Pick<InitializeParams, "workspaceFolders" | "rootUri">,
+): WorkspaceFolder[] => {
+  if (params.workspaceFolders?.length) {
+    return [...params.workspaceFolders];
+  }
+
+  return params.rootUri
+    ? [{ uri: params.rootUri, name: params.rootUri }]
+    : [];
+};

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -2,6 +2,8 @@ import type { TextDocument } from "vscode-languageserver-textdocument";
 import type {
   FileUri,
   WorkspaceFile,
+  listWorkspaceFiles,
+  readWorkspaceFile,
 } from "../server/content_provider.ts";
 
 export type WorkspaceFileReader = (
@@ -10,4 +12,9 @@ export type WorkspaceFileReader = (
 
 export type TextDocumentProvider = {
   get(uri: string): TextDocument | undefined;
+};
+
+export type ContentProvider = {
+  listWorkspaceFiles: typeof listWorkspaceFiles;
+  readWorkspaceFile: typeof readWorkspaceFile;
 };

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,7 +1,12 @@
 import type { TextDocument } from "vscode-languageserver-textdocument";
-import type { FileContent, Filename } from "../handlers/compilation/includes";
+import type {
+  FileUri,
+  WorkspaceFile,
+} from "../server/content_provider.ts";
 
-export type FileSystemReader = (filename: Filename) => Promise<FileContent>;
+export type WorkspaceFileReader = (
+  uri: FileUri,
+) => Promise<WorkspaceFile | null>;
 
 export type TextDocumentProvider = {
   get(uri: string): TextDocument | undefined;


### PR DESCRIPTION
Another prerequisite for multi-file renaming. The language server needs to have a way of discovering all stan files in the workspace. In order to acchieve this, this PR introduces a `content_provider` module that exposes two functions:
- `listWorkspaceFiles`
- `readWorkspaceFile`

The latter one replace the `FileSystemReader` we had so far. The new implementation goes beyond what the old reader did in that it first checks wether a document is already open (via the document_state) we introduced in a recent commit. Only if it isn't does it read the file from disk.